### PR TITLE
external dns, longhorn updates

### DIFF
--- a/inventory/inventory.ini
+++ b/inventory/inventory.ini
@@ -2,7 +2,6 @@ t440
 baxter
 rhel0
 docker0
-doc ansible_user=pollen
 node0
 node1
 node2

--- a/manifests/core/external-dns/install.yaml
+++ b/manifests/core/external-dns/install.yaml
@@ -9,8 +9,8 @@ kind: ClusterRole
 metadata:
   name: external-dns
 rules:
-- apiGroups: [""]
-  resources: ["services","endpoints","pods"]
+- apiGroups: ["", "discovery.k8s.io"]
+  resources: ["services","endpoints","pods","endpointslices"]
   verbs: ["get","watch","list"]
 - apiGroups: ["extensions","networking.k8s.io"]
   resources: ["ingresses"]
@@ -41,11 +41,11 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      app: external-dns
+      app: external-dns-0
   template:
     metadata:
       labels:
-        app: external-dns
+        app: external-dns-0
     spec:
       serviceAccountName: external-dns
       containers:
@@ -72,7 +72,7 @@ spec:
         - --pihole-api-version=6
         # Change this to the actual address of your Pi-hole web server
         #- --pihole-server=http://pihole-web.default.svc.cluster.local
-        - --pihole-server=http://192.168.0.233
+        - --pihole-server=http://pihole2.homelab.test
       securityContext:
         fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes token files
 ---
@@ -85,11 +85,11 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      app: external-dns
+      app: external-dns-1
   template:
     metadata:
       labels:
-        app: external-dns
+        app: external-dns-1
     spec:
       serviceAccountName: external-dns
       containers:

--- a/manifests/core/external-dns/install.yaml
+++ b/manifests/core/external-dns/install.yaml
@@ -50,7 +50,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns-0
-        image: registry.k8s.io/external-dns/external-dns:v0.17.0
+        image: registry.k8s.io/external-dns/external-dns:v0.20.0
         # If authentication is disabled and/or you didn't create
         # a secret, you can remove this block.
         envFrom:
@@ -72,7 +72,7 @@ spec:
         - --pihole-api-version=6
         # Change this to the actual address of your Pi-hole web server
         #- --pihole-server=http://pihole-web.default.svc.cluster.local
-        - --pihole-server=http://192.168.0.239
+        - --pihole-server=http://192.168.0.233
       securityContext:
         fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes token files
 ---
@@ -94,7 +94,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns-1
-        image: registry.k8s.io/external-dns/external-dns:v0.17.0
+        image: registry.k8s.io/external-dns/external-dns:v0.20.0
         # If authentication is disabled and/or you didn't create
         # a secret, you can remove this block.
         envFrom:

--- a/manifests/core/longhorn/.helmignore
+++ b/manifests/core/longhorn/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/manifests/core/longhorn/Chart.yaml
+++ b/manifests/core/longhorn/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+appVersion: v1.11.0
+description: Longhorn is a distributed block storage system for Kubernetes.
+home: https://github.com/longhorn/longhorn
+icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/longhorn/icon/color/longhorn-icon-color.png
+keywords:
+- longhorn
+- storage
+- distributed
+- block
+- device
+- iscsi
+- nfs
+kubeVersion: '>=1.25.0-0'
+maintainers:
+- email: maintainers@longhorn.io
+  name: Longhorn maintainers
+name: longhorn
+sources:
+- https://github.com/longhorn/longhorn
+- https://github.com/longhorn/longhorn-engine
+- https://github.com/longhorn/longhorn-instance-manager
+- https://github.com/longhorn/longhorn-share-manager
+- https://github.com/longhorn/longhorn-manager
+- https://github.com/longhorn/longhorn-ui
+- https://github.com/longhorn/longhorn-tests
+- https://github.com/longhorn/backing-image-manager
+version: 1.11.0

--- a/manifests/core/longhorn/README.md
+++ b/manifests/core/longhorn/README.md
@@ -1,2 +1,411 @@
-Make sure to have `open-iscsi` and nfs tools installed on your nodes. Use the
-`playbooks/k8s/install_longhorn_requirements.yml`
+# Longhorn Chart
+
+> **Important**: Please install the Longhorn chart in the `longhorn-system` namespace only.
+
+> **Warning**: Longhorn doesn't support downgrading from a higher version to a lower version.
+
+> **Note**: Use Helm 3 when installing and upgrading Longhorn. Helm 2 is [no longer supported](https://helm.sh/blog/helm-2-becomes-unsupported/).
+
+## Source Code
+
+Longhorn is 100% open source software. Project source code is spread across a number of repos:
+
+1. Longhorn Engine -- Core controller/replica logic https://github.com/longhorn/longhorn-engine
+2. Longhorn Instance Manager -- Controller/replica instance lifecycle management https://github.com/longhorn/longhorn-instance-manager
+3. Longhorn Share Manager -- NFS provisioner that exposes Longhorn volumes as ReadWriteMany volumes. https://github.com/longhorn/longhorn-share-manager
+4. Backing Image Manager -- Backing image file lifecycle management. https://github.com/longhorn/backing-image-manager
+5. Longhorn Manager -- Longhorn orchestration, includes CSI driver for Kubernetes https://github.com/longhorn/longhorn-manager
+6. Longhorn UI -- Dashboard https://github.com/longhorn/longhorn-ui
+
+## Prerequisites
+
+1. A container runtime compatible with Kubernetes (Docker v1.13+, containerd v1.3.7+, etc.)
+2. Kubernetes >= v1.25
+3. Make sure `bash`, `curl`, `findmnt`, `grep`, `awk` and `blkid` has been installed in all nodes of the Kubernetes cluster.
+4. Make sure `open-iscsi` has been installed, and the `iscsid` daemon is running on all nodes of the Kubernetes cluster. For GKE, recommended Ubuntu as guest OS image since it contains `open-iscsi` already.
+
+## Upgrading to Kubernetes v1.25+
+
+Starting in Kubernetes v1.25, [Pod Security Policies](https://kubernetes.io/docs/concepts/security/pod-security-policy/) have been removed from the Kubernetes API.
+
+As a result, **before upgrading to Kubernetes v1.25** (or on a fresh install in a Kubernetes v1.25+ cluster), users are expected to perform an in-place upgrade of this chart with `enablePSP` set to `false` if it has been previously set to `true`.
+
+> **Note:**
+> If you upgrade your cluster to Kubernetes v1.25+ before removing PSPs via a `helm upgrade` (even if you manually clean up resources), **it will leave the Helm release in a broken state within the cluster such that further Helm operations will not work (`helm uninstall`, `helm upgrade`, etc.).**
+>
+> If your charts get stuck in this state, you may have to clean up your Helm release secrets.
+Upon setting `enablePSP` to false, the chart will remove any PSP resources deployed on its behalf from the cluster. This is the default setting for this chart.
+
+As a replacement for PSPs, [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) should be used. Please consult the Longhorn docs for more details on how to configure your chart release namespaces to work with the new Pod Security Admission and apply Pod Security Standards.
+
+## Installation
+
+1. Add Longhorn chart repository.
+```
+helm repo add longhorn https://charts.longhorn.io
+```
+
+2. Update local Longhorn chart information from chart repository.
+```
+helm repo update
+```
+
+3. Use the following commands to create the `longhorn-system` namespace first, then install the Longhorn chart.
+
+```
+kubectl create namespace longhorn-system
+helm install longhorn longhorn/longhorn --namespace longhorn-system
+```
+
+## Uninstallation
+
+```
+kubectl -n longhorn-system patch -p '{"value": "true"}' --type=merge lhs deleting-confirmation-flag
+helm uninstall longhorn -n longhorn-system
+kubectl delete namespace longhorn-system
+```
+
+## Values
+
+The `values.yaml` contains items used to tweak a deployment of this chart.
+
+### Cattle Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| global.cattle.systemDefaultRegistry | string | `""` | Default system registry. |
+| global.cattle.windowsCluster.defaultSetting.systemManagedComponentsNodeSelector | string | `"kubernetes.io/os:linux"` | Node selector for system-managed Longhorn components. |
+| global.cattle.windowsCluster.defaultSetting.taintToleration | string | `"cattle.io/os=linux:NoSchedule"` | Toleration for system-managed Longhorn components. |
+| global.cattle.windowsCluster.enabled | bool | `false` | Setting that allows Longhorn to run on a Rancher Windows cluster. |
+| global.cattle.windowsCluster.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for Linux nodes that can run user-deployed Longhorn components. |
+| global.cattle.windowsCluster.tolerations | list | `[{"effect":"NoSchedule","key":"cattle.io/os","operator":"Equal","value":"linux"}]` | Toleration for Linux nodes that can run user-deployed Longhorn components. |
+| global.imagePullSecrets | list | `[]` | Global override for image pull secrets for container registry. |
+| global.imageRegistry | string | `"docker.io"` | Global override for container image registry. |
+| global.nodeSelector | object | `{}` | Node selector for nodes allowed to run user-deployed components such as Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer. |
+| global.timezone | string | `""` | Set container timezone (TZ env) for all Longhorn workloads. Leave empty to use container default. |
+| global.tolerations | list | `[]` | Toleration for nodes allowed to run user-deployed components such as Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer. |
+
+### Network Policies
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| networkPolicies.enabled | bool | `false` | Setting that allows you to enable network policies that control access to Longhorn pods. |
+| networkPolicies.type | string | `"k3s"` | Distribution that determines the policy for allowing access for an ingress. (Options: "k3s", "rke2", "rke1") |
+
+### Image Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| image.csi.attacher.registry | string | `""` | Registry for the CSI attacher image. When unspecified, Longhorn uses the default value. |
+| image.csi.attacher.repository | string | `"longhornio/csi-attacher"` | Repository for the CSI attacher image. When unspecified, Longhorn uses the default value. |
+| image.csi.attacher.tag | string | `"v4.10.0-20251226"` | Tag for the CSI attacher image. When unspecified, Longhorn uses the default value. |
+| image.csi.livenessProbe.registry | string | `""` | Registry for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
+| image.csi.livenessProbe.repository | string | `"longhornio/livenessprobe"` | Repository for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
+| image.csi.livenessProbe.tag | string | `"v2.17.0-20251226"` | Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
+| image.csi.nodeDriverRegistrar.registry | string | `""` | Registry for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
+| image.csi.nodeDriverRegistrar.repository | string | `"longhornio/csi-node-driver-registrar"` | Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
+| image.csi.nodeDriverRegistrar.tag | string | `"v2.15.0-20251226"` | Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
+| image.csi.provisioner.registry | string | `""` | Registry for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
+| image.csi.provisioner.repository | string | `"longhornio/csi-provisioner"` | Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
+| image.csi.provisioner.tag | string | `"v5.3.0-20251226"` | Tag for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
+| image.csi.resizer.registry | string | `""` | Registry for the CSI Resizer image. When unspecified, Longhorn uses the default value. |
+| image.csi.resizer.repository | string | `"longhornio/csi-resizer"` | Repository for the CSI Resizer image. When unspecified, Longhorn uses the default value. |
+| image.csi.resizer.tag | string | `"v2.0.0-20251226"` | Tag for the CSI Resizer image. When unspecified, Longhorn uses the default value. |
+| image.csi.snapshotter.registry | string | `""` | Registry for the CSI Snapshotter image. When unspecified, Longhorn uses the default value. |
+| image.csi.snapshotter.repository | string | `"longhornio/csi-snapshotter"` | Repository for the CSI Snapshotter image. When unspecified, Longhorn uses the default value. |
+| image.csi.snapshotter.tag | string | `"v8.4.0-20251226"` | Tag for the CSI Snapshotter image. When unspecified, Longhorn uses the default value. |
+| image.longhorn.backingImageManager.registry | string | `""` | Registry for the Backing Image Manager image. When unspecified, Longhorn uses the default value. |
+| image.longhorn.backingImageManager.repository | string | `"longhornio/backing-image-manager"` | Repository for the Backing Image Manager image. When unspecified, Longhorn uses the default value. |
+| image.longhorn.backingImageManager.tag | string | `"v1.11.0-rc3"` | Tag for the Backing Image Manager image. When unspecified, Longhorn uses the default value. |
+| image.longhorn.engine.registry | string | `""` | Registry for the Longhorn Engine image. |
+| image.longhorn.engine.repository | string | `"longhornio/longhorn-engine"` | Repository for the Longhorn Engine image. |
+| image.longhorn.engine.tag | string | `"v1.11.0-rc3"` | Tag for the Longhorn Engine image. |
+| image.longhorn.instanceManager.registry | string | `""` | Registry for the Longhorn Instance Manager image. |
+| image.longhorn.instanceManager.repository | string | `"longhornio/longhorn-instance-manager"` | Repository for the Longhorn Instance Manager image. |
+| image.longhorn.instanceManager.tag | string | `"v1.11.0-rc3"` | Tag for the Longhorn Instance Manager image. |
+| image.longhorn.manager.registry | string | `""` | Registry for the Longhorn Manager image. |
+| image.longhorn.manager.repository | string | `"longhornio/longhorn-manager"` | Repository for the Longhorn Manager image. |
+| image.longhorn.manager.tag | string | `"v1.11.0-rc3"` | Tag for the Longhorn Manager image. |
+| image.longhorn.shareManager.registry | string | `""` | Registry for the Longhorn Share Manager image. |
+| image.longhorn.shareManager.repository | string | `"longhornio/longhorn-share-manager"` | Repository for the Longhorn Share Manager image. |
+| image.longhorn.shareManager.tag | string | `"v1.11.0-rc3"` | Tag for the Longhorn Share Manager image. |
+| image.longhorn.supportBundleKit.registry | string | `""` | Registry for the Longhorn Support Bundle Manager image. |
+| image.longhorn.supportBundleKit.repository | string | `"longhornio/support-bundle-kit"` | Repository for the Longhorn Support Bundle Manager image. |
+| image.longhorn.supportBundleKit.tag | string | `"v0.0.79"` | Tag for the Longhorn Support Bundle Manager image. |
+| image.longhorn.ui.registry | string | `""` | Registry for the Longhorn UI image. |
+| image.longhorn.ui.repository | string | `"longhornio/longhorn-ui"` | Repository for the Longhorn UI image. |
+| image.longhorn.ui.tag | string | `"v1.11.0-rc3"` | Tag for the Longhorn UI image. |
+| image.openshift.oauthProxy.registry | string | `""` | Registry for the OAuth Proxy image. Specify the upstream image (for example, "quay.io/openshift/origin-oauth-proxy"). This setting applies only to OpenShift users. |
+| image.openshift.oauthProxy.repository | string | `""` | Repository for the OAuth Proxy image. Specify the upstream image (for example, "quay.io/openshift/origin-oauth-proxy"). This setting applies only to OpenShift users. |
+| image.openshift.oauthProxy.tag | string | `""` | Tag for the OAuth Proxy image. Specify OCP/OKD version 4.1 or later (including version 4.18, which is available at quay.io/openshift/origin-oauth-proxy:4.18). This setting applies only to OpenShift users. |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy that applies to all user-deployed Longhorn components, such as Longhorn Manager, Longhorn driver, and Longhorn UI. |
+
+### Service Settings
+
+| Key | Description |
+|-----|-------------|
+| service.manager.nodePort | NodePort port number for Longhorn Manager. When unspecified, Longhorn selects a free port between 30000 and 32767. |
+| service.manager.type | Service type for Longhorn Manager. |
+| service.ui.annotations | Annotation for the Longhorn UI service. |
+| service.ui.labels |  |
+| service.ui.loadBalancerClass | Class of a load balancer implementation |
+| service.ui.nodePort | NodePort port number for Longhorn UI. When unspecified, Longhorn selects a free port between 30000 and 32767. |
+| service.ui.type | Service type for Longhorn UI. (Options: "ClusterIP", "NodePort", "LoadBalancer", "Rancher-Proxy") |
+
+### StorageClass Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| persistence.backingImage.dataSourceParameters | string | `nil` | Data source parameters of a backing image used in a Longhorn StorageClass. You can specify a JSON string of a map. (Example: `'{\"url\":\"https://backing-image-example.s3-region.amazonaws.com/test-backing-image\"}'`) |
+| persistence.backingImage.dataSourceType | string | `nil` | Data source type of a backing image used in a Longhorn StorageClass. If the backing image exists in the cluster, Longhorn uses this setting to verify the image. If the backing image does not exist, Longhorn creates one using the specified data source type. |
+| persistence.backingImage.enable | bool | `false` | Setting that allows you to use a backing image in a Longhorn StorageClass. |
+| persistence.backingImage.expectedChecksum | string | `nil` | Expected SHA-512 checksum of a backing image used in a Longhorn StorageClass. |
+| persistence.backingImage.name | string | `nil` | Backing image to be used for creating and restoring volumes in a Longhorn StorageClass. When no backing images are available, specify the data source type and parameters that Longhorn can use to create a backing image. |
+| persistence.backupTargetName | string | `"default"` | Setting that allows you to specify the backup target for the default Longhorn StorageClass. |
+| persistence.dataEngine | string | `"v1"` | Setting that allows you to specify the data engine version for the default Longhorn StorageClass. (Options: "v1", "v2") |
+| persistence.defaultClass | bool | `true` | Setting that allows you to specify the default Longhorn StorageClass. |
+| persistence.defaultClassReplicaCount | int | `3` | Replica count of the default Longhorn StorageClass. |
+| persistence.defaultDataLocality | string | `"disabled"` | Data locality of the default Longhorn StorageClass. (Options: "disabled", "best-effort") |
+| persistence.defaultDiskSelector.enable | bool | `false` | Setting that allows you to enable the disk selector for the default Longhorn StorageClass. |
+| persistence.defaultDiskSelector.selector | string | `""` | Disk selector for the default Longhorn StorageClass. Longhorn uses only disks with the specified tags for storing volume data. (Examples: "nvme,sata") |
+| persistence.defaultFsType | string | `"ext4"` | Filesystem type of the default Longhorn StorageClass. |
+| persistence.defaultMkfsParams | string | `""` | mkfs parameters of the default Longhorn StorageClass. |
+| persistence.defaultNodeSelector.enable | bool | `false` | Setting that allows you to enable the node selector for the default Longhorn StorageClass. |
+| persistence.defaultNodeSelector.selector | string | `""` | Node selector for the default Longhorn StorageClass. Longhorn uses only nodes with the specified tags for storing volume data. (Examples: "storage,fast") |
+| persistence.disableRevisionCounter | string | `"true"` | Setting that disables the revision counter and thereby prevents Longhorn from tracking all write operations to a volume. When salvaging a volume, Longhorn uses properties of the volume-head-xxx.img file (the last file size and the last time the file was modified) to select the replica to be used for volume recovery. |
+| persistence.migratable | bool | `false` | Setting that allows you to enable live migration of a Longhorn volume from one node to another. |
+| persistence.nfsOptions | string | `""` | Set NFS mount options for Longhorn StorageClass for RWX volumes |
+| persistence.reclaimPolicy | string | `"Delete"` | Reclaim policy that provides instructions for handling of a volume after its claim is released. (Options: "Retain", "Delete") |
+| persistence.recurringJobSelector.enable | bool | `false` | Setting that allows you to enable the recurring job selector for a Longhorn StorageClass. |
+| persistence.recurringJobSelector.jobList | list | `[]` | Recurring job selector for a Longhorn StorageClass. Ensure that quotes are used correctly when specifying job parameters. (Example: `[{"name":"backup", "isGroup":true}]`) |
+| persistence.unmapMarkSnapChainRemoved | string | `"ignored"` | Setting that allows you to enable automatic snapshot removal during filesystem trim for a Longhorn StorageClass. (Options: "ignored", "enabled", "disabled") |
+| persistence.volumeBindingMode | string | `"Immediate"` | VolumeBindingMode controls when volume binding and dynamic provisioning should occur. (Options: "Immediate", "WaitForFirstConsumer") (Defaults to "Immediate") |
+
+### CSI Settings
+
+| Key | Description |
+|-----|-------------|
+| csi.attacherReplicaCount | Replica count of the CSI Attacher. When unspecified, Longhorn uses the default value ("3"). |
+| csi.kubeletRootDir | kubelet root directory. When unspecified, Longhorn uses the default value. |
+| csi.podAntiAffinityPreset | Configures Pod anti-affinity to prevent multiple instances on the same node. Use soft (tries to separate) or hard (must separate). When unspecified, Longhorn uses the default value ("soft"). |
+| csi.provisionerReplicaCount | Replica count of the CSI Provisioner. When unspecified, Longhorn uses the default value ("3"). |
+| csi.resizerReplicaCount | Replica count of the CSI Resizer. When unspecified, Longhorn uses the default value ("3"). |
+| csi.snapshotterReplicaCount | Replica count of the CSI Snapshotter. When unspecified, Longhorn uses the default value ("3"). |
+
+### Longhorn Manager Settings
+
+Longhorn consists of user-deployed components (for example, Longhorn Manager, Longhorn Driver, and Longhorn UI) and system-managed components (for example, Instance Manager, Backing Image Manager, Share Manager, CSI Driver, and Engine Image). The following settings only apply to Longhorn Manager.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| longhornManager.log.format | string | `"plain"` | Format of Longhorn Manager logs. (Options: "plain", "json") |
+| longhornManager.nodeSelector | object | `{}` | Node selector for Longhorn Manager. Specify the nodes allowed to run Longhorn Manager. |
+| longhornManager.priorityClass | string | `"longhorn-critical"` | PriorityClass for Longhorn Manager. |
+| longhornManager.resources | string | `nil` | Resource requests and limits for Longhorn Manager pods. |
+| longhornManager.serviceAnnotations | object | `{}` | Annotation for the Longhorn Manager service. |
+| longhornManager.serviceLabels | object | `{}` |  |
+| longhornManager.tolerations | list | `[]` | Toleration for Longhorn Manager on nodes allowed to run Longhorn components. |
+| longhornManager.updateStrategy.rollingUpdate.maxUnavailable | string | `"100%"` |  |
+
+### Longhorn Driver Settings
+
+Longhorn consists of user-deployed components (for example, Longhorn Manager, Longhorn Driver, and Longhorn UI) and system-managed components (for example, Instance Manager, Backing Image Manager, Share Manager, CSI Driver, and Engine Image). The following settings only apply to Longhorn Driver.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| longhornDriver.log.format | string | `"plain"` | Format of longhorn-driver logs. (Options: "plain", "json") |
+| longhornDriver.nodeSelector | object | `{}` | Node selector for Longhorn Driver. Specify the nodes allowed to run Longhorn Driver. |
+| longhornDriver.priorityClass | string | `"longhorn-critical"` | PriorityClass for Longhorn Driver. |
+| longhornDriver.tolerations | list | `[]` | Toleration for Longhorn Driver on nodes allowed to run Longhorn components. |
+
+### Longhorn UI Settings
+
+Longhorn consists of user-deployed components (for example, Longhorn Manager, Longhorn Driver, and Longhorn UI) and system-managed components (for example, Instance Manager, Backing Image Manager, Share Manager, CSI Driver, and Engine Image). The following settings only apply to Longhorn UI.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| longhornUI.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app","operator":"In","values":["longhorn-ui"]}]},"topologyKey":"kubernetes.io/hostname"},"weight":1}]}}` | Affinity for Longhorn UI pods. Specify the affinity you want to use for Longhorn UI. |
+| longhornUI.nodeSelector | object | `{}` | Node selector for Longhorn UI. Specify the nodes allowed to run Longhorn UI. |
+| longhornUI.priorityClass | string | `"longhorn-critical"` | PriorityClass for Longhorn UI. |
+| longhornUI.replicas | int | `2` | Replica count for Longhorn UI. |
+| longhornUI.tolerations | list | `[]` | Toleration for Longhorn UI on nodes allowed to run Longhorn components. |
+
+### Ingress Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| ingress.annotations | string | `nil` | Ingress annotations in the form of key-value pairs. |
+| ingress.enabled | bool | `false` | Setting that allows Longhorn to generate ingress records for the Longhorn UI service. |
+| ingress.extraHosts | list | `[]` | Extra hostnames for TLS (Subject Alternative Names - SAN). Used when you need multiple FQDNs for the same ingress. Example: extraHosts:   - longhorn.example.com   - longhorn-ui.internal.local |
+| ingress.host | string | `"sslip.io"` | Hostname of the Layer 7 load balancer. |
+| ingress.ingressClassName | string | `nil` | IngressClass resource that contains ingress configuration, including the name of the Ingress controller. ingressClassName can replace the kubernetes.io/ingress.class annotation used in earlier Kubernetes releases. |
+| ingress.path | string | `"/"` | Default ingress path. You can access the Longhorn UI by following the full ingress path {{host}}+{{path}}. |
+| ingress.pathType | string | `"ImplementationSpecific"` | Ingress path type. To maintain backward compatibility, the default value is "ImplementationSpecific". |
+| ingress.secrets | string | `nil` | Secret that contains a TLS private key and certificate. Use secrets if you want to use your own certificates to secure ingresses. |
+| ingress.secureBackends | bool | `false` | Setting that allows you to enable secure connections to the Longhorn UI service via port 443. |
+| ingress.tls | bool | `false` | Setting that allows you to enable TLS on ingress records. |
+| ingress.tlsSecret | string | `"longhorn.local-tls"` | TLS secret that contains the private key and certificate to be used for TLS. This setting applies only when TLS is enabled on ingress records. |
+
+### HTTPRoute Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| httproute.annotations | object | `{}` | Annotations for the HTTPRoute resource in the form of key-value pairs. |
+| httproute.enabled | bool | `false` | Setting that allows Longhorn to generate HTTPRoute records for the Longhorn UI service using Gateway API. |
+| httproute.hostnames | list | `[]` | List of hostnames for the HTTPRoute. Multiple hostnames are supported. |
+| httproute.parentRefs | list | `[]` | Gateway references for HTTPRoute. Specify which Gateway(s) should handle this route. |
+| httproute.path | string | `"/"` | Default path for HTTPRoute. You can access the Longhorn UI by following the full path. |
+| httproute.pathType | string | `"PathPrefix"` | Path match type for HTTPRoute. (Options: "Exact", "PathPrefix") |
+
+### Private Registry Settings
+
+You can install Longhorn in an air-gapped environment with a private registry. For more information, see the **Air Gap Installation** section of the [documentation](https://longhorn.io/docs).
+
+| Key | Description |
+|-----|-------------|
+| privateRegistry.createSecret | Set to `true` to automatically create a new private registry secret. |
+| privateRegistry.registryPasswd | Password for authenticating with a private registry. |
+| privateRegistry.registrySecret | If create a new private registry secret is true, create a Kubernetes secret with this name; else use the existing secret of this name. Use it to pull images from your private registry. |
+| privateRegistry.registryUrl | URL of a private registry. When unspecified, Longhorn uses the default system registry. |
+| privateRegistry.registryUser | User account used for authenticating with a private registry. |
+
+### Metrics Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| metrics.serviceMonitor.additionalLabels | object | `{}` | Additional labels for the Prometheus ServiceMonitor resource. |
+| metrics.serviceMonitor.annotations | object | `{}` | Annotations for the Prometheus ServiceMonitor resource. |
+| metrics.serviceMonitor.enabled | bool | `false` | Setting that allows the creation of a Prometheus ServiceMonitor resource for Longhorn Manager components. |
+| metrics.serviceMonitor.interval | string | `""` | Interval at which Prometheus scrapes the metrics from the target. |
+| metrics.serviceMonitor.metricRelabelings | list | `[]` | Configures the relabeling rules to apply to the samples before ingestion. See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Endpoint) for formatting details. |
+| metrics.serviceMonitor.relabelings | list | `[]` | Configures the relabeling rules to apply the target’s metadata labels. See the [Prometheus Operator documentation](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Endpoint) for formatting details. |
+| metrics.serviceMonitor.scrapeTimeout | string | `""` | Timeout after which Prometheus considers the scrape to be failed. |
+
+### OS/Kubernetes Distro Settings
+
+#### OpenShift Settings
+
+For more details, see the [ocp-readme](https://github.com/longhorn/longhorn/blob/master/chart/ocp-readme.md).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| openshift.enabled | bool | `false` | Setting that allows Longhorn to integrate with OpenShift. |
+| openshift.ui.port | int | `443` | Port for accessing the OpenShift web console. |
+| openshift.ui.proxy | int | `8443` | Port for proxy that provides access to the OpenShift web console. |
+| openshift.ui.route | string | `"longhorn-ui"` | Route for connections between Longhorn and the OpenShift web console. |
+
+### Other Settings
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| annotations | `{}` | Annotation for the Longhorn Manager DaemonSet pods. This setting is optional. |
+| defaultBackupStore | `{"backupTarget":null,"backupTargetCredentialSecret":null,"pollInterval":null}` | Setting that allows you to update the default backupstore. |
+| defaultBackupStore.backupTarget | `nil` | Endpoint used to access the default backupstore. (Options: "NFS", "CIFS", "AWS", "GCP", "AZURE") |
+| defaultBackupStore.backupTargetCredentialSecret | `nil` | Name of the Kubernetes secret associated with the default backup target. |
+| defaultBackupStore.pollInterval | `nil` | Number of seconds that Longhorn waits before checking the default backupstore for new backups. The default value is "300". When the value is "0", polling is disabled. |
+| enableGoCoverDir | `false` | Setting that allows Longhorn to generate code coverage profiles. |
+| enablePSP | `false` | Setting that allows you to enable pod security policies (PSPs) that allow privileged Longhorn pods to start. This setting applies only to clusters running Kubernetes 1.25 and earlier, and with the built-in Pod Security admission controller enabled. |
+| extraObjects | `[]` | Add extra objects manifests |
+| namespaceOverride | `""` | Specify override namespace, specifically this is useful for using longhorn as sub-chart and its release namespace is not the `longhorn-system`. |
+| preUpgradeChecker.jobEnabled | `true` | Setting that allows Longhorn to perform pre-upgrade checks. Disable this setting when installing Longhorn using Argo CD or other GitOps solutions. |
+| preUpgradeChecker.upgradeVersionCheck | `true` | Setting that allows Longhorn to perform upgrade version checks after starting the Longhorn Manager DaemonSet Pods. Disabling this setting also disables `preUpgradeChecker.jobEnabled`. Longhorn recommends keeping this setting enabled. |
+
+### System Default Settings
+
+During installation, you can either allow Longhorn to use the default system settings or use specific flags to modify the default values. After installation, you can modify the settings using the Longhorn UI. For more information, see the **Settings Reference** section of the [documentation](https://longhorn.io/docs).
+
+| Key | Description |
+|-----|-------------|
+| defaultSettings.allowCollectingLonghornUsageMetrics | Setting that allows Longhorn to periodically collect anonymous usage data for product improvement purposes. Longhorn sends collected data to the [Upgrade Responder](https://github.com/longhorn/upgrade-responder) server, which is the data source of the Longhorn Public Metrics Dashboard (https://metrics.longhorn.io). The Upgrade Responder server does not store data that can be used to identify clients, including IP addresses. |
+| defaultSettings.allowEmptyDiskSelectorVolume | Setting that allows scheduling of empty disk selector volumes to any disk. |
+| defaultSettings.allowEmptyNodeSelectorVolume | Setting that allows scheduling of empty node selector volumes to any node. |
+| defaultSettings.allowRecurringJobWhileVolumeDetached | Setting that allows Longhorn to automatically attach a volume and create snapshots or backups when recurring jobs are run. |
+| defaultSettings.allowVolumeCreationWithDegradedAvailability | Setting that allows you to create and attach a volume without having all replicas scheduled at the time of creation. |
+| defaultSettings.autoCleanupRecurringJobBackupSnapshot | Setting that allows Longhorn to automatically clean up the snapshot generated by a recurring backup job. |
+| defaultSettings.autoCleanupSnapshotAfterOnDemandBackupCompleted | Setting that automatically cleans up the snapshot after the on-demand backup is completed. |
+| defaultSettings.autoCleanupSnapshotWhenDeleteBackup | Setting that automatically cleans up the snapshot when the backup is deleted. |
+| defaultSettings.autoCleanupSystemGeneratedSnapshot | Setting that allows Longhorn to automatically clean up the system-generated snapshot after replica rebuilding is completed. |
+| defaultSettings.autoDeletePodWhenVolumeDetachedUnexpectedly | Setting that allows Longhorn to automatically delete a workload pod that is managed by a controller (for example, daemonset) whenever a Longhorn volume is detached unexpectedly (for example, during Kubernetes upgrades). After deletion, the controller restarts the pod and then Kubernetes handles volume reattachment and remounting. |
+| defaultSettings.autoSalvage | Setting that allows Longhorn to automatically salvage volumes when all replicas become faulty (for example, when the network connection is interrupted). Longhorn determines which replicas are usable and then uses these replicas for the volume. This setting is enabled by default. |
+| defaultSettings.backingImageCleanupWaitInterval | Number of minutes that Longhorn waits before cleaning up the backing image file when no replicas in the disk are using it. |
+| defaultSettings.backingImageRecoveryWaitInterval | Number of seconds that Longhorn waits before downloading a backing image file again when the status of all image disk files changes to "failed" or "unknown". |
+| defaultSettings.backupCompressionMethod | Setting that allows you to specify a backup compression method. |
+| defaultSettings.backupConcurrentLimit | Maximum number of worker threads that can concurrently run for each backup. |
+| defaultSettings.backupExecutionTimeout | Number of minutes that Longhorn allows for the backup execution. The default value is "1". |
+| defaultSettings.blacklistForAutoDeletePodWhenVolumeDetachedUnexpectedly | Blacklist of controller api/kind values for the setting Automatically Delete Workload Pod when the Volume Is Detached Unexpectedly. If a workload pod is managed by a controller whose api/kind is listed in this blacklist, Longhorn will not automatically delete the pod when its volume is unexpectedly detached. Multiple controller api/kind entries can be specified, separated by semicolons. For example: `apps/StatefulSet;apps/DaemonSet`. Note that the controller api/kind is case sensitive and must exactly match the api/kind in the workload pod's owner reference. |
+| defaultSettings.concurrentAutomaticEngineUpgradePerNodeLimit | Maximum number of engines that are allowed to concurrently upgrade on each node after Longhorn Manager is upgraded. When the value is "0", Longhorn does not automatically upgrade volume engines to the new default engine image version. |
+| defaultSettings.concurrentReplicaRebuildPerNodeLimit | Maximum number of replicas that can be concurrently rebuilt on each node. |
+| defaultSettings.concurrentVolumeBackupRestorePerNodeLimit | Maximum number of volumes that can be concurrently restored on each node using a backup. When the value is "0", restoration of volumes using a backup is disabled. |
+| defaultSettings.createDefaultDiskLabeledNodes | Setting that allows Longhorn to automatically create a default disk only on nodes with the label "node.longhorn.io/create-default-disk=true" (if no other disks exist). When this setting is disabled, Longhorn creates a default disk on each node that is added to the cluster. |
+| defaultSettings.dataEngineCPUMask | Applies only to the V2 Data Engine. Specifies the CPU cores on which the Storage Performance Development Kit (SPDK) target daemon runs. The daemon is deployed in each Instance Manager pod. Ensure that the number of assigned cores does not exceed the guaranteed Instance Manager CPUs for the V2 Data Engine. The default value is "{"v2":"0x1"}". |
+| defaultSettings.dataEngineHugepageEnabled | Applies only to the V2 Data Engine. Enables hugepages for the Storage Performance Development Kit (SPDK) target daemon. If disabled, legacy memory is used. Allocation size is set via the Data Engine Memory Size setting. |
+| defaultSettings.dataEngineLogFlags | Applies only to the V2 Data Engine. Specifies the log flags for the Storage Performance Development Kit (SPDK) target daemon. |
+| defaultSettings.dataEngineLogLevel | Applies only to the V2 Data Engine. Specifies the log level for the Storage Performance Development Kit (SPDK) target daemon. Supported values are: Error, Warning, Notice, Info, and Debug. The default is Notice. |
+| defaultSettings.dataEngineMemorySize | Applies only to the V2 Data Engine. Specifies the hugepage size, in MiB, for the Storage Performance Development Kit (SPDK) target daemon. The default value is "{"v2":"2048"}" |
+| defaultSettings.defaultBackupBlockSize | Specifies the default backup block size, in MiB, used when creating a new volume. Supported values are 2 or 16. |
+| defaultSettings.defaultDataLocality | Default data locality. A Longhorn volume has data locality if a local replica of the volume exists on the same node as the pod that is using the volume. |
+| defaultSettings.defaultDataPath | Default path to use for storing data on a host. An absolute directory path indicates a filesystem-type disk used by the V1 Data Engine, while a path to a block device indicates a block-type disk used by the V2 Data Engine. The default value is "/var/lib/longhorn/". |
+| defaultSettings.defaultLonghornStaticStorageClass | Default name of Longhorn static StorageClass. "storageClassName" is assigned to PVs and PVCs that are created for an existing Longhorn volume. "storageClassName" can also be used as a label, so it is possible to use a Longhorn StorageClass to bind a workload to an existing PV without creating a Kubernetes StorageClass object. "storageClassName" needs to be an existing StorageClass. The default value is "longhorn-static". |
+| defaultSettings.defaultReplicaCount | Default number of replicas for volumes created using the Longhorn UI. For Kubernetes configuration, modify the `numberOfReplicas` field in the StorageClass. The default value is "{"v1":"3","v2":"3"}". |
+| defaultSettings.defaultUblkNumberOfQueue | This setting specifies the default the number of queues for ublk frontend. This setting applies to volumes using the V2 Data Engine with Ublk front end. Individual volumes can override this setting by specifying their own number of queues for ublk. |
+| defaultSettings.defaultUblkQueueDepth | This setting specifies the default depth of each queue for Ublk frontend. This setting applies to volumes using the V2 Data Engine with Ublk front end. Individual volumes can override this setting by specifying their own Ublk queue depth. |
+| defaultSettings.deletingConfirmationFlag | Flag that prevents accidental uninstallation of Longhorn. |
+| defaultSettings.detachManuallyAttachedVolumesWhenCordoned | Setting that allows automatic detaching of manually-attached volumes when a node is cordoned. |
+| defaultSettings.disableRevisionCounter | Setting that disables the revision counter and thereby prevents Longhorn from tracking all write operations to a volume. When salvaging a volume, Longhorn uses properties of the "volume-head-xxx.img" file (the last file size and the last time the file was modified) to select the replica to be used for volume recovery. This setting applies only to volumes created using the Longhorn UI. |
+| defaultSettings.disableSchedulingOnCordonedNode | Setting that prevents Longhorn Manager from scheduling replicas on a cordoned Kubernetes node. This setting is enabled by default. |
+| defaultSettings.disableSnapshotPurge | Setting that temporarily prevents all attempts to purge volume snapshots. |
+| defaultSettings.endpointNetworkForRWXVolume | Specifies a dedicated network for mounting RWX (ReadWriteMany) volumes. Leave this blank to use the default Kubernetes cluster network. **Caution**: This setting should change after all RWX volumes are detached because some Longhorn component pods must be recreated to apply the setting. You cannot modify this setting while RWX volumes are still attached. |
+| defaultSettings.engineReplicaTimeout | Timeout between the Longhorn Engine and replicas. Specify a value between "8" and "30" seconds. The default value is "8". |
+| defaultSettings.failedBackupTTL | Number of minutes that Longhorn keeps a failed backup resource. When the value is "0", automatic deletion is disabled. |
+| defaultSettings.fastReplicaRebuildEnabled | Setting that allows fast rebuilding of replicas using the checksum of snapshot disk files. Before enabling this setting, you must set the snapshot-data-integrity value to "enable" or "fast-check". |
+| defaultSettings.freezeFilesystemForSnapshot | Setting that freezes the filesystem on the root partition before a snapshot is created. |
+| defaultSettings.guaranteedInstanceManagerCPU | Percentage of the total allocatable CPU resources on each node to be reserved for each instance manager pod. The default value is {"v1":"12","v2":"12"}. |
+| defaultSettings.instanceManagerPodLivenessProbeTimeout | In seconds. The setting specifies the timeout for the instance manager pod liveness probe. The default value is 10 seconds. |
+| defaultSettings.kubernetesClusterAutoscalerEnabled | Setting that notifies Longhorn that the cluster is using the Kubernetes Cluster Autoscaler. |
+| defaultSettings.logLevel | Log levels that indicate the type and severity of logs in Longhorn Manager. The default value is "Info". (Options: "Panic", "Fatal", "Error", "Warn", "Info", "Debug", "Trace") |
+| defaultSettings.logPath | Specifies the directory on the host where Longhorn stores log files for the instance manager pod. Currently, it is only used for instance manager pods in the v2 data engine. |
+| defaultSettings.longGRPCTimeOut | Number of seconds that Longhorn allows for the completion of replica rebuilding and snapshot cloning operations. |
+| defaultSettings.managerUrl | The external URL used to access the Longhorn Manager API. When set, this URL is returned in API responses (the actions and links fields) instead of the internal pod IP. This is useful when accessing the API through Ingress or Gateway API HTTPRoute. Format: scheme://host[:port] (for example, https://longhorn.example.com or https://longhorn.example.com:8443). Leave it empty to use the default behavior. |
+| defaultSettings.nodeDiskHealthMonitoring | Controls whether Longhorn monitors and records health information for node disks. When disabled, disk health checks and status updates are skipped. |
+| defaultSettings.nodeDownPodDeletionPolicy | Policy that defines the action Longhorn takes when a volume is stuck with a StatefulSet or Deployment pod on a node that failed. |
+| defaultSettings.nodeDrainPolicy | Policy that defines the action Longhorn takes when a node with the last healthy replica of a volume is drained. |
+| defaultSettings.offlineReplicaRebuilding | Enables automatic rebuilding of degraded replicas while the volume is detached. This setting only takes effect if the individual volume setting is set to `ignored` or `enabled`. |
+| defaultSettings.orphanResourceAutoDeletion | Enables Longhorn to automatically delete orphaned resources and their associated data or processes (e.g., stale replicas). Orphaned resources on failed or unknown nodes are not automatically cleaned up. You need to specify the resource types to be deleted using a semicolon-separated list (e.g., `replica-data;instance`). Available items are: `replica-data`, `instance`. |
+| defaultSettings.orphanResourceAutoDeletionGracePeriod | Specifies the wait time, in seconds, before Longhorn automatically deletes an orphaned Custom Resource (CR) and its associated resources. Note that if a user manually deletes an orphaned CR, the deletion occurs immediately and does not respect this grace period. |
+| defaultSettings.priorityClass | PriorityClass for system-managed Longhorn components. This setting can help prevent Longhorn components from being evicted under Node Pressure. Notice that this will be applied to Longhorn user-deployed components by default if there are no priority class values set yet, such as `longhornManager.priorityClass`. |
+| defaultSettings.rebuildConcurrentSyncLimit | Maximum number of file synchronization operations that can run concurrently during a single replica rebuild. Right now, it's for v1 data engine only. |
+| defaultSettings.recurringFailedJobsHistoryLimit | Maximum number of failed recurring backup and snapshot jobs to be retained. When the value is "0", a history of failed recurring jobs is not retained. |
+| defaultSettings.recurringJobMaxRetention | Maximum number of snapshots or backups to be retained. |
+| defaultSettings.recurringSuccessfulJobsHistoryLimit | Maximum number of successful recurring backup and snapshot jobs to be retained. When the value is "0", a history of successful recurring jobs is not retained. |
+| defaultSettings.removeSnapshotsDuringFilesystemTrim | Setting that allows Longhorn to automatically mark the latest snapshot and its parent files as removed during a filesystem trim. Longhorn does not remove snapshots containing multiple child files. |
+| defaultSettings.replicaAutoBalance | Setting that automatically rebalances replicas when an available node is discovered. |
+| defaultSettings.replicaDiskSoftAntiAffinity | Setting that allows scheduling on disks with existing healthy replicas of the same volume. This setting is enabled by default. |
+| defaultSettings.replicaFileSyncHttpClientTimeout | Number of seconds that an HTTP client waits for a response from a File Sync server before considering the connection to have failed. |
+| defaultSettings.replicaRebuildingBandwidthLimit | This setting specifies the default write bandwidth limit (in megabytes per second) for volume replica rebuilding when using the v2 data engine (SPDK). If this value is set to 0, there will be no write bandwidth limitation. Individual volumes can override this setting by specifying their own rebuilding bandwidth limit. |
+| defaultSettings.replicaReplenishmentWaitInterval | Number of seconds that Longhorn waits before reusing existing data on a failed replica instead of creating a new replica of a degraded volume. |
+| defaultSettings.replicaSoftAntiAffinity | Setting that allows scheduling on nodes with healthy replicas of the same volume. This setting is disabled by default. |
+| defaultSettings.replicaZoneSoftAntiAffinity | Setting that allows Longhorn to schedule new replicas of a volume to nodes in the same zone as existing healthy replicas. Nodes that do not belong to any zone are treated as existing in the zone that contains healthy replicas. When identifying zones, Longhorn relies on the label "topology.kubernetes.io/zone=<Zone name of the node>" in the Kubernetes node object. |
+| defaultSettings.restoreConcurrentLimit | Maximum number of worker threads that can concurrently run for each restore operation. |
+| defaultSettings.restoreVolumeRecurringJobs | Setting that restores recurring jobs from a backup volume on a backup target and creates recurring jobs if none exist during backup restoration. |
+| defaultSettings.rwxVolumeFastFailover | Setting that allows Longhorn to detect node failure and immediately migrate affected RWX volumes. |
+| defaultSettings.snapshotDataIntegrity | Setting that allows you to enable and disable snapshot hashing and data integrity checks. |
+| defaultSettings.snapshotDataIntegrityCronjob | Setting that defines when Longhorn checks the integrity of data in snapshot disk files. You must use the Unix cron expression format. |
+| defaultSettings.snapshotDataIntegrityImmediateCheckAfterSnapshotCreation | Setting that allows disabling of snapshot hashing after snapshot creation to minimize impact on system performance. |
+| defaultSettings.snapshotHeavyTaskConcurrentLimit | Setting that controls how many snapshot heavy task operations (such as purge and clone) can run concurrently per node. This is a best-effort mechanism: due to the distributed nature of the system, temporary oversubscription may occur. The limiter reduces worst-case overload but does not guarantee perfect enforcement. |
+| defaultSettings.snapshotMaxCount | Maximum snapshot count for a volume. The value should be between 2 to 250 |
+| defaultSettings.storageMinimalAvailablePercentage | Percentage of minimum available disk capacity. When the minimum available capacity exceeds the total available capacity, the disk becomes unschedulable until more space is made available for use. The default value is "25". |
+| defaultSettings.storageNetwork | Storage network for in-cluster traffic. When unspecified, Longhorn uses the Kubernetes cluster network. |
+| defaultSettings.storageOverProvisioningPercentage | Percentage of storage that can be allocated relative to hard drive capacity. The default value is "100". |
+| defaultSettings.storageReservedPercentageForDefaultDisk | Percentage of disk space that is not allocated to the default disk on each new Longhorn node. |
+| defaultSettings.supportBundleFailedHistoryLimit | Maximum number of failed support bundles that can exist in the cluster. When the value is "0", Longhorn automatically purges all failed support bundles. |
+| defaultSettings.systemManagedCSIComponentsResourceLimits | Resource limits for system-managed CSI components. This setting allows you to configure CPU and memory requests/limits for CSI attacher, provisioner, resizer, snapshotter, and plugin components. Supported components: csi-attacher, csi-provisioner, csi-resizer, csi-snapshotter, longhorn-csi-plugin, node-driver-registrar, longhorn-liveness-probe. Notice that changing resource limits will cause CSI components to restart, which may temporarily affect volume provisioning and attach/detach operations until the components are ready. The value should be a JSON object with component names as keys and ResourceRequirements as values. |
+| defaultSettings.systemManagedComponentsNodeSelector | Node selector for system-managed Longhorn components. |
+| defaultSettings.systemManagedPodsImagePullPolicy | Image pull policy for system-managed pods, such as Instance Manager, engine images, and CSI Driver. Changes to the image pull policy are applied only after the system-managed pods restart. |
+| defaultSettings.taintToleration | Taint or toleration for system-managed Longhorn components. Specify values using a semicolon-separated list in `kubectl taint` syntax (Example: key1=value1:effect; key2=value2:effect). |
+| defaultSettings.upgradeChecker | Upgrade Checker that periodically checks for new Longhorn versions. When a new version is available, a notification appears on the Longhorn UI. This setting is enabled by default |
+| defaultSettings.upgradeResponderURL | The Upgrade Responder sends a notification whenever a new Longhorn version that you can upgrade to becomes available. The default value is https://longhorn-upgrade-responder.rancher.io/v1/checkupgrade. |
+| defaultSettings.v1DataEngine | Setting that allows you to enable the V1 Data Engine. |
+| defaultSettings.v2DataEngine | Setting that allows you to enable the V2 Data Engine, which is based on the Storage Performance Development Kit (SPDK). The V2 Data Engine is an experimental feature and should not be used in production environments. |
+
+---
+Please see [link](https://github.com/longhorn/longhorn) for more information.

--- a/manifests/core/longhorn/README.md.gotmpl
+++ b/manifests/core/longhorn/README.md.gotmpl
@@ -1,0 +1,261 @@
+# Longhorn Chart
+
+> **Important**: Please install the Longhorn chart in the `longhorn-system` namespace only.
+
+> **Warning**: Longhorn doesn't support downgrading from a higher version to a lower version.
+
+> **Note**: Use Helm 3 when installing and upgrading Longhorn. Helm 2 is [no longer supported](https://helm.sh/blog/helm-2-becomes-unsupported/).
+
+## Source Code
+
+Longhorn is 100% open source software. Project source code is spread across a number of repos:
+
+1. Longhorn Engine -- Core controller/replica logic https://github.com/longhorn/longhorn-engine
+2. Longhorn Instance Manager -- Controller/replica instance lifecycle management https://github.com/longhorn/longhorn-instance-manager
+3. Longhorn Share Manager -- NFS provisioner that exposes Longhorn volumes as ReadWriteMany volumes. https://github.com/longhorn/longhorn-share-manager
+4. Backing Image Manager -- Backing image file lifecycle management. https://github.com/longhorn/backing-image-manager
+5. Longhorn Manager -- Longhorn orchestration, includes CSI driver for Kubernetes https://github.com/longhorn/longhorn-manager
+6. Longhorn UI -- Dashboard https://github.com/longhorn/longhorn-ui
+
+## Prerequisites
+
+1. A container runtime compatible with Kubernetes (Docker v1.13+, containerd v1.3.7+, etc.)
+2. Kubernetes >= v1.25
+3. Make sure `bash`, `curl`, `findmnt`, `grep`, `awk` and `blkid` has been installed in all nodes of the Kubernetes cluster.
+4. Make sure `open-iscsi` has been installed, and the `iscsid` daemon is running on all nodes of the Kubernetes cluster. For GKE, recommended Ubuntu as guest OS image since it contains `open-iscsi` already.
+
+## Upgrading to Kubernetes v1.25+
+
+Starting in Kubernetes v1.25, [Pod Security Policies](https://kubernetes.io/docs/concepts/security/pod-security-policy/) have been removed from the Kubernetes API.
+
+As a result, **before upgrading to Kubernetes v1.25** (or on a fresh install in a Kubernetes v1.25+ cluster), users are expected to perform an in-place upgrade of this chart with `enablePSP` set to `false` if it has been previously set to `true`.
+
+> **Note:**
+> If you upgrade your cluster to Kubernetes v1.25+ before removing PSPs via a `helm upgrade` (even if you manually clean up resources), **it will leave the Helm release in a broken state within the cluster such that further Helm operations will not work (`helm uninstall`, `helm upgrade`, etc.).**
+>
+> If your charts get stuck in this state, you may have to clean up your Helm release secrets.
+Upon setting `enablePSP` to false, the chart will remove any PSP resources deployed on its behalf from the cluster. This is the default setting for this chart.
+
+As a replacement for PSPs, [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) should be used. Please consult the Longhorn docs for more details on how to configure your chart release namespaces to work with the new Pod Security Admission and apply Pod Security Standards.
+
+## Installation
+
+1. Add Longhorn chart repository.
+```
+helm repo add longhorn https://charts.longhorn.io
+```
+
+2. Update local Longhorn chart information from chart repository.
+```
+helm repo update
+```
+
+3. Use the following commands to create the `longhorn-system` namespace first, then install the Longhorn chart.
+
+```
+kubectl create namespace longhorn-system
+helm install longhorn longhorn/longhorn --namespace longhorn-system
+```
+
+## Uninstallation
+
+```
+kubectl -n longhorn-system patch -p '{"value": "true"}' --type=merge lhs deleting-confirmation-flag
+helm uninstall longhorn -n longhorn-system
+kubectl delete namespace longhorn-system
+```
+
+## Values
+
+The `values.yaml` contains items used to tweak a deployment of this chart.
+
+### Cattle Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "global" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### Network Policies
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "networkPolicies" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### Image Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "image" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### Service Settings
+
+| Key | Description |
+|-----|-------------|
+{{- range .Values }}
+  {{- if (and (hasPrefix "service" .Key) (not (contains "Account" .Key))) }}
+| {{ .Key }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### StorageClass Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "persistence" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### CSI Settings
+
+| Key | Description |
+|-----|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "csi" .Key }}
+| {{ .Key }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### Longhorn Manager Settings
+
+Longhorn consists of user-deployed components (for example, Longhorn Manager, Longhorn Driver, and Longhorn UI) and system-managed components (for example, Instance Manager, Backing Image Manager, Share Manager, CSI Driver, and Engine Image). The following settings only apply to Longhorn Manager.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "longhornManager" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### Longhorn Driver Settings
+
+Longhorn consists of user-deployed components (for example, Longhorn Manager, Longhorn Driver, and Longhorn UI) and system-managed components (for example, Instance Manager, Backing Image Manager, Share Manager, CSI Driver, and Engine Image). The following settings only apply to Longhorn Driver.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "longhornDriver" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### Longhorn UI Settings
+
+Longhorn consists of user-deployed components (for example, Longhorn Manager, Longhorn Driver, and Longhorn UI) and system-managed components (for example, Instance Manager, Backing Image Manager, Share Manager, CSI Driver, and Engine Image). The following settings only apply to Longhorn UI.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "longhornUI" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### Ingress Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "ingress" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### HTTPRoute Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "httproute" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### Private Registry Settings
+
+You can install Longhorn in an air-gapped environment with a private registry. For more information, see the **Air Gap Installation** section of the [documentation](https://longhorn.io/docs).
+
+| Key | Description |
+|-----|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "privateRegistry" .Key }}
+| {{ .Key }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### Metrics Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "metrics" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### OS/Kubernetes Distro Settings
+
+#### OpenShift Settings
+
+For more details, see the [ocp-readme](https://github.com/longhorn/longhorn/blob/master/chart/ocp-readme.md).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "openshift" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### Other Settings
+
+| Key | Default | Description |
+|-----|---------|-------------|
+{{- range .Values }}
+  {{- if not (or (hasPrefix "defaultSettings" .Key)
+  (hasPrefix "networkPolicies" .Key)
+  (hasPrefix "image" .Key)
+  (hasPrefix "service" .Key)
+  (hasPrefix "persistence" .Key)
+  (hasPrefix "csi" .Key)
+  (hasPrefix "longhornManager" .Key)
+  (hasPrefix "longhornDriver" .Key)
+  (hasPrefix "longhornUI" .Key)
+  (hasPrefix "privateRegistry" .Key)
+  (hasPrefix "ingress" .Key)
+  (hasPrefix "httproute" .Key)
+  (hasPrefix "metrics" .Key)
+  (hasPrefix "openshift" .Key)
+  (hasPrefix "global" .Key)) }}
+| {{ .Key }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### System Default Settings
+
+During installation, you can either allow Longhorn to use the default system settings or use specific flags to modify the default values. After installation, you can modify the settings using the Longhorn UI. For more information, see the **Settings Reference** section of the [documentation](https://longhorn.io/docs).
+
+| Key | Description |
+|-----|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "defaultSettings" .Key }}
+| {{ .Key }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+---
+Please see [link](https://github.com/longhorn/longhorn) for more information.

--- a/manifests/core/longhorn/app-readme.md
+++ b/manifests/core/longhorn/app-readme.md
@@ -1,0 +1,11 @@
+# Longhorn
+
+Longhorn is a lightweight, reliable and easy to use distributed block storage system for Kubernetes. Once deployed, users can leverage persistent volumes provided by Longhorn.
+
+Longhorn creates a dedicated storage controller for each volume and synchronously replicates the volume across multiple replicas stored on multiple nodes. The storage controller and replicas are themselves orchestrated using Kubernetes. Longhorn supports snapshots, backups and even allows you to schedule recurring snapshots and backups!
+
+**Important**: Please install Longhorn chart in `longhorn-system` namespace only.
+
+**Warning**: Longhorn doesn't support downgrading from a higher version to a lower version.
+
+[Chart Documentation](https://github.com/longhorn/longhorn/blob/master/chart/README.md)

--- a/manifests/core/longhorn/ocp-readme.md
+++ b/manifests/core/longhorn/ocp-readme.md
@@ -1,0 +1,178 @@
+# OpenShift / OKD Extra Configuration Steps
+
+- [OpenShift / OKD Extra Configuration Steps](#openshift--okd-extra-configuration-steps)
+  - [Notes](#notes)
+  - [Known Issues](#known-issues)
+  - [Preparing Nodes (Optional)](#preparing-nodes-optional)
+    - [Default /var/lib/longhorn setup](#default-varliblonghorn-setup)
+    - [Separate /var/mnt/longhorn setup](#separate-varmntlonghorn-setup)
+      - [Create Filesystem](#create-filesystem)
+      - [Mounting Disk On Boot](#mounting-disk-on-boot)
+      - [Label and Annotate Nodes](#label-and-annotate-nodes)
+  - [Example values.yaml](#example-valuesyaml)
+  - [Installation](#installation)
+  - [Refs](#refs)
+
+## Notes
+
+Main changes and tasks for OCP are:
+
+- On OCP / OKD, the Operating System is Managed by the Cluster
+- OCP Imposes [Security Context Constraints](https://docs.openshift.com/container-platform/4.11/authentication/managing-security-context-constraints.html)
+  - This requires everything to run with the least privilege possible. For the moment every component has been given access to run as higher privilege.
+  - Something to circle back on is network polices and which components can have their privileges reduced without impacting functionality.
+    - The UI probably can be for example.
+- openshift/oauth-proxy for authentication to the Longhorn Ui
+  - **⚠️** Currently Scoped to Authenticated Users that can delete a longhorn settings object.
+    - **⚠️** Since the UI it self is not protected, network policies will need to be created to prevent namespace <--> namespace communication against the pod or service object directly.
+    - Anyone with access to the UI Deployment can remove the route restriction. (Namespace Scoped Admin)
+- Option to use separate disk in /var/mnt/longhorn & MachineConfig file to mount /var/mnt/longhorn
+- Adding finalizers for mount propagation
+
+## Known Issues
+
+- General Feature/Issue Thread
+  - [[FEATURE] Deploying Longhorn on OKD/Openshift](https://github.com/longhorn/longhorn/issues/1831)
+- 4.10 / 1.23:
+  - 4.10.0-0.okd-2022-03-07-131213 to 4.10.0-0.okd-2022-07-09-073606
+    - Tested, No Known Issues
+- 4.11 / 1.24:
+  - 4.11.0-0.okd-2022-07-27-052000 to 4.11.0-0.okd-2022-11-19-050030
+    - Tested, No Known Issues
+  - 4.11.0-0.okd-2022-12-02-145640, 4.11.0-0.okd-2023-01-14-152430:
+    - Workaround: [[BUG] Volumes Stuck in Attach/Detach Loop](https://github.com/longhorn/longhorn/issues/4988)
+      - [MachineConfig Patch](https://github.com/longhorn/longhorn/issues/4988#issuecomment-1345676772)
+- 4.12 / 1.25:
+  - 4.12.0-0.okd-2022-12-05-210624 to 4.12.0-0.okd-2023-01-20-101927
+    - Tested, No Known Issues
+  - 4.12.0-0.okd-2023-01-21-055900 to 4.12.0-0.okd-2023-02-18-033438:
+    - Workaround: [[BUG] Volumes Stuck in Attach/Detach Loop](https://github.com/longhorn/longhorn/issues/4988)
+      - [MachineConfig Patch](https://github.com/longhorn/longhorn/issues/4988#issuecomment-1345676772)
+  - 4.12.0-0.okd-2023-03-05-022504 - 4.12.0-0.okd-2023-04-16-041331:
+    - Tested, No Known Issues
+- 4.13 / 1.26:
+  - 4.13.0-0.okd-2023-05-03-001308 - 4.13.0-0.okd-2023-08-18-135805:
+    - Tested, No Known Issues
+- 4.14 / 1.27:
+  - 4.14.0-0.okd-2023-08-12-022330 - 4.14.0-0.okd-2023-10-28-073550:
+    - Tested, No Known Issues
+
+## Preparing Nodes (Optional)
+
+Only required if you require additional customizations, such as storage-less nodes, or secondary disks.
+
+### Default /var/lib/longhorn setup
+
+Label each node for storage with:
+
+```bash
+oc get nodes --no-headers | awk '{print $1}'
+
+export NODE="worker-0"
+oc label node "${NODE}" node.longhorn.io/create-default-disk=true
+```
+
+### Separate /var/mnt/longhorn setup
+
+#### Create Filesystem
+
+On the storage nodes create a filesystem with the label longhorn:
+
+```bash
+oc get nodes --no-headers | awk '{print $1}'
+
+export NODE="worker-0"
+oc debug node/${NODE} -t -- chroot /host bash
+
+# Validate Target Drive is Present
+lsblk
+
+export DRIVE="sdb" #vdb
+sudo mkfs.ext4 -L longhorn /dev/${DRIVE}
+```
+
+> ⚠️ Note: If you add New Nodes After the below Machine Config is applied, you will need to also reboot the node.
+
+#### Mounting Disk On Boot
+
+The Secondary Drive needs to be mounted on every boot. Save the Concents and Apply the MachineConfig with `oc apply -f`:
+
+> ⚠️ This will trigger an machine config profile update and reboot all worker nodes on the cluster
+
+```yaml
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 71-mount-storage-worker
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+        - name: var-mnt-longhorn.mount
+          enabled: true
+          contents: |
+            [Unit]
+            Before=local-fs.target
+            [Mount]
+            Where=/var/mnt/longhorn
+            What=/dev/disk/by-label/longhorn
+            Options=rw,relatime,discard
+            [Install]
+            WantedBy=local-fs.target
+```
+
+#### Label and Annotate Nodes
+
+Label and annotate storage nodes like this:
+
+```bash
+oc get nodes --no-headers | awk '{print $1}'
+
+export NODE="worker-0"
+oc annotate node ${NODE} --overwrite node.longhorn.io/default-disks-config='[{"path":"/var/mnt/longhorn","allowScheduling":true}]'
+oc label node ${NODE} node.longhorn.io/create-default-disk=config
+```
+
+## Example values.yaml
+
+Minimum Adjustments Required
+
+```yaml
+image:
+  openshift:
+    oauthProxy:
+      repository: quay.io/openshift/origin-oauth-proxy
+      tag: 4.18  # Use Your OCP/OKD 4.X Version, Current Stable is 4.18
+
+# defaultSettings: # Preparing nodes (Optional)
+  # createDefaultDiskLabeledNodes: true
+
+openshift:
+  enabled: true
+  ui:
+    route: "longhorn-ui"
+    port: 443
+    proxy: 8443
+```
+
+## Installation
+
+```bash
+# helm template ./chart/ --namespace longhorn-system --values ./chart/values.yaml --no-hooks > longhorn.yaml # Local Testing
+helm template longhorn --namespace longhorn-system --values values.yaml --no-hooks  > longhorn.yaml
+oc create namespace longhorn-system -o yaml --dry-run=client | oc apply -f -
+oc apply -f longhorn.yaml -n longhorn-system
+```
+
+## Refs
+
+- <https://docs.openshift.com/container-platform/4.11/storage/persistent_storage/persistent-storage-iscsi.html>
+- <https://docs.okd.io/4.11/storage/persistent_storage/persistent-storage-iscsi.html>
+- okd 4.5: <https://github.com/longhorn/longhorn/issues/1831#issuecomment-702690613>
+- okd 4.6: <https://github.com/longhorn/longhorn/issues/1831#issuecomment-765884631>
+- oauth-proxy: <https://github.com/openshift/oauth-proxy/blob/master/contrib/sidecar.yaml>
+- <https://github.com/longhorn/longhorn/issues/1831>

--- a/manifests/core/longhorn/questions.yaml
+++ b/manifests/core/longhorn/questions.yaml
@@ -1,0 +1,1289 @@
+categories:
+  - storage
+namespace: longhorn-system
+questions:
+  - variable: image.defaultImage
+    default: 'true'
+    description: Use default Longhorn images
+    label: Use Default Images
+    type: boolean
+    show_subquestion_if: false
+    group: Longhorn Images
+    subquestions:
+      - variable: image.longhorn.manager.repository
+        default: longhornio/longhorn-manager
+        description: Repository for the Longhorn Manager image.
+        type: string
+        label: Longhorn Manager Image Repository
+        group: Longhorn Images Settings
+      - variable: image.longhorn.manager.tag
+        default: v1.11.0
+        description: Tag for the Longhorn Manager image.
+        type: string
+        label: Longhorn Manager Image Tag
+        group: Longhorn Images Settings
+      - variable: image.longhorn.engine.repository
+        default: longhornio/longhorn-engine
+        description: Repository for the Longhorn Engine image.
+        type: string
+        label: Longhorn Engine Image Repository
+        group: Longhorn Images Settings
+      - variable: image.longhorn.engine.tag
+        default: v1.11.0
+        description: Tag for the Longhorn Engine image.
+        type: string
+        label: Longhorn Engine Image Tag
+        group: Longhorn Images Settings
+      - variable: image.longhorn.ui.repository
+        default: longhornio/longhorn-ui
+        description: Repository for the Longhorn UI image.
+        type: string
+        label: Longhorn UI Image Repository
+        group: Longhorn Images Settings
+      - variable: image.longhorn.ui.tag
+        default: v1.11.0
+        description: Tag for the Longhorn UI image.
+        type: string
+        label: Longhorn UI Image Tag
+        group: Longhorn Images Settings
+      - variable: image.longhorn.instanceManager.repository
+        default: longhornio/longhorn-instance-manager
+        description: Repository for the Longhorn Instance Manager image.
+        type: string
+        label: Longhorn Instance Manager Image Repository
+        group: Longhorn Images Settings
+      - variable: image.longhorn.instanceManager.tag
+        default: v1.11.0
+        description: Tag for the Longhorn Instance Manager image.
+        type: string
+        label: Longhorn Instance Manager Image Tag
+        group: Longhorn Images Settings
+      - variable: image.longhorn.shareManager.repository
+        default: longhornio/longhorn-share-manager
+        description: Repository for the Longhorn Share Manager image.
+        type: string
+        label: Longhorn Share Manager Image Repository
+        group: Longhorn Images Settings
+      - variable: image.longhorn.shareManager.tag
+        default: v1.11.0
+        description: Tag for the Longhorn Share Manager image.
+        type: string
+        label: Longhorn Share Manager Image Tag
+        group: Longhorn Images Settings
+      - variable: image.longhorn.backingImageManager.repository
+        default: longhornio/backing-image-manager
+        description: >-
+          Repository for the Backing Image Manager image. When unspecified, Longhorn uses the default value.
+        type: string
+        label: Longhorn Backing Image Manager Image Repository
+        group: Longhorn Images Settings
+      - variable: image.longhorn.backingImageManager.tag
+        default: v1.11.0
+        description: >-
+          Tag for the Backing Image Manager image. When unspecified, Longhorn uses the default value.
+        type: string
+        label: Longhorn Backing Image Manager Image Tag
+        group: Longhorn Images Settings
+      - variable: image.longhorn.supportBundleKit.repository
+        default: longhornio/support-bundle-kit
+        description: Repository for the Longhorn Support Bundle Manager image.
+        type: string
+        label: Longhorn Support Bundle Kit Image Repository
+        group: Longhorn Images Settings
+      - variable: image.longhorn.supportBundleKit.tag
+        default: v0.0.79
+        description: Tag for the Longhorn Support Bundle Manager image.
+        type: string
+        label: Longhorn Support Bundle Kit Image Tag
+        group: Longhorn Images Settings
+      - variable: image.csi.attacher.repository
+        default: longhornio/csi-attacher
+        description: >-
+          Repository for the CSI attacher image. When unspecified, Longhorn uses the default value.
+        type: string
+        label: Longhorn CSI Attacher Image Repository
+        group: Longhorn CSI Driver Images
+      - variable: image.csi.attacher.tag
+        default: v4.10.0-20251226
+        description: >-
+          Tag for the CSI attacher image. When unspecified, Longhorn uses the default value.
+        type: string
+        label: Longhorn CSI Attacher Image Tag
+        group: Longhorn CSI Driver Images
+      - variable: image.csi.provisioner.repository
+        default: longhornio/csi-provisioner
+        description: >-
+          Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value.
+        type: string
+        label: Longhorn CSI Provisioner Image Repository
+        group: Longhorn CSI Driver Images
+      - variable: image.csi.provisioner.tag
+        default: v5.3.0-20251226
+        description: >-
+          Tag for the CSI Provisioner image. When unspecified, Longhorn uses the default value.
+        type: string
+        label: Longhorn CSI Provisioner Image Tag
+        group: Longhorn CSI Driver Images
+      - variable: image.csi.nodeDriverRegistrar.repository
+        default: longhornio/csi-node-driver-registrar
+        description: >-
+          Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value.
+        type: string
+        label: Longhorn CSI Node Driver Registrar Image Repository
+        group: Longhorn CSI Driver Images
+      - variable: image.csi.nodeDriverRegistrar.tag
+        default: v2.15.0-20251226
+        description: >-
+          Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value.
+        type: string
+        label: Longhorn CSI Node Driver Registrar Image Tag
+        group: Longhorn CSI Driver Images
+      - variable: image.csi.resizer.repository
+        default: longhornio/csi-resizer
+        description: >-
+          Repository for the CSI Resizer image. When unspecified, Longhorn uses the default value.
+        type: string
+        label: Longhorn CSI Driver Resizer Image Repository
+        group: Longhorn CSI Driver Images
+      - variable: image.csi.resizer.tag
+        default: v2.0.0-20251226
+        description: >-
+          Tag for the CSI Resizer image. When unspecified, Longhorn uses the default value.
+        type: string
+        label: Longhorn CSI Driver Resizer Image Tag
+        group: Longhorn CSI Driver Images
+      - variable: image.csi.snapshotter.repository
+        default: longhornio/csi-snapshotter
+        description: >-
+          Repository for the CSI Snapshotter image. When unspecified, Longhorn uses the default value.
+        type: string
+        label: Longhorn CSI Driver Snapshotter Image Repository
+        group: Longhorn CSI Driver Images
+      - variable: image.csi.snapshotter.tag
+        default: v8.4.0-20251226
+        description: >-
+          Tag for the CSI Snapshotter image. When unspecified, Longhorn uses the default value.
+        type: string
+        label: Longhorn CSI Driver Snapshotter Image Tag
+        group: Longhorn CSI Driver Images
+      - variable: image.csi.livenessProbe.repository
+        default: longhornio/livenessprobe
+        description: >-
+          Repository for the CSI liveness probe image. When unspecified, Longhorn uses the default value.
+        type: string
+        label: Longhorn CSI Liveness Probe Image Repository
+        group: Longhorn CSI Driver Images
+      - variable: image.csi.livenessProbe.tag
+        default: v2.17.0-20251226
+        description: >-
+          Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value.
+        type: string
+        label: Longhorn CSI Liveness Probe Image Tag
+        group: Longhorn CSI Driver Images
+  - variable: privateRegistry.registryUrl
+    label: Private registry URL
+    description: >-
+      URL of a private registry. When unspecified, Longhorn uses the default system registry.
+    group: Private Registry Settings
+    type: string
+    default: ''
+    subquestions: []
+  - variable: privateRegistry.registrySecret
+    label: Private registry secret name
+    description: >-
+      If create a new private registry secret is true, create a Kubernetes secret with this name; else use the existing secret of this name. Use it to pull images from your private registry.
+    group: Private Registry Settings
+    type: string
+    default: ''
+    subquestions: []
+  - variable: privateRegistry.createSecret
+    default: 'true'
+    description: Set to true to automatically create a new private registry secret.
+    type: boolean
+    group: Private Registry Settings
+    label: Create Secret for Private Registry Settings
+    show_subquestion_if: true
+    subquestions:
+      - variable: privateRegistry.registryUser
+        label: Private registry user
+        description: User account used for authenticating with a private registry.
+        type: string
+        default: ''
+      - variable: privateRegistry.registryPasswd
+        label: Private registry password
+        description: Password for authenticating with a private registry.
+        type: password
+        default: ''
+  - variable: longhorn.default_setting
+    default: 'false'
+    description: >-
+      Customize the default settings before installing Longhorn for the first time. This option will only work if the cluster hasn't installed Longhorn.
+    label: Customize Default Settings
+    type: boolean
+    show_subquestion_if: true
+    group: Longhorn Default Settings
+    subquestions:
+      - variable: csi.kubeletRootDir
+        default: null
+        description: >-
+          kubelet root directory. When unspecified, Longhorn uses the default value.
+        type: string
+        label: Kubelet Root Directory
+        group: Longhorn CSI Driver Settings
+      - variable: csi.podAntiAffinityPreset
+        type: string
+        label: Longhorn CSI Pod AntiAffinity Preset
+        group: Longhorn CSI Driver Settings
+        default: soft
+        description: >-
+          Configures Pod anti-affinity to prevent multiple instances on the same node. Use soft (tries to separate) or hard (must separate). When unspecified, Longhorn uses the default value ("soft").
+      - variable: csi.attacherReplicaCount
+        type: int
+        default: 3
+        min: 1
+        max: 10
+        description: >-
+          Replica count of the CSI Attacher. When unspecified, Longhorn uses the default value ("3").
+        label: Longhorn CSI Attacher replica count
+        group: Longhorn CSI Driver Settings
+      - variable: csi.provisionerReplicaCount
+        type: int
+        default: 3
+        min: 1
+        max: 10
+        description: >-
+          Replica count of the CSI Provisioner. When unspecified, Longhorn uses the default value ("3").
+        label: Longhorn CSI Provisioner replica count
+        group: Longhorn CSI Driver Settings
+      - variable: csi.resizerReplicaCount
+        type: int
+        default: 3
+        min: 1
+        max: 10
+        description: >-
+          Replica count of the CSI Resizer. When unspecified, Longhorn uses the default value ("3").
+        label: Longhorn CSI Resizer replica count
+        group: Longhorn CSI Driver Settings
+      - variable: csi.snapshotterReplicaCount
+        type: int
+        default: 3
+        min: 1
+        max: 10
+        description: >-
+          Replica count of the CSI Snapshotter. When unspecified, Longhorn uses the default value ("3").
+        label: Longhorn CSI Snapshotter replica count
+        group: Longhorn CSI Driver Settings
+      - variable: defaultSettings.allowRecurringJobWhileVolumeDetached
+        label: Allow Recurring Job While Volume Is Detached
+        description: >-
+          Setting that allows Longhorn to automatically attach a volume and create snapshots or backups when recurring jobs are run.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'false'
+      - variable: defaultSettings.snapshotMaxCount
+        label: Snapshot Maximum Count
+        description: >-
+          Maximum snapshot count for a volume. The value should be between 2 to 250.
+        group: Longhorn Default Settings
+        type: int
+        min: 2
+        max: 250
+        default: 250
+      - variable: defaultSettings.createDefaultDiskLabeledNodes
+        label: Create Default Disk on Labeled Nodes
+        description: >-
+          Setting that allows Longhorn to automatically create a default disk only on nodes with the label "node.longhorn.io/create-default-disk=true" (if no other disks exist). When this setting is disabled, Longhorn creates a default disk on each node that is added to the cluster.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'false'
+      - variable: defaultSettings.defaultDataPath
+        label: Default Data Path
+        description: >-
+          Default path to use for storing data on a host. An absolute directory path indicates a filesystem-type disk used by the V1 Data Engine, while a path to a block device indicates a block-type disk used by the V2 Data Engine. The default value is "/var/lib/longhorn/".
+        group: Longhorn Default Settings
+        type: string
+        default: /var/lib/longhorn/
+      - variable: defaultSettings.defaultDataLocality
+        label: Default Data Locality
+        description: >-
+          Default data locality. A Longhorn volume has data locality if a local replica of the volume exists on the same node as the pod that is using the volume.
+        group: Longhorn Default Settings
+        type: enum
+        options:
+          - disabled
+          - best-effort
+        default: disabled
+      - variable: defaultSettings.replicaSoftAntiAffinity
+        label: Replica Node Level Soft Anti-Affinity
+        description: >-
+          Allow scheduling on nodes with existing healthy replicas of the same volume. By default, false.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'false'
+      - variable: defaultSettings.replicaAutoBalance
+        label: Replica Auto Balance
+        description: >-
+          Enable this setting automatically re-balances replicas when discovered an available node.
+        group: Longhorn Default Settings
+        type: enum
+        options:
+          - disabled
+          - least-effort
+          - best-effort
+        default: disabled
+      - variable: defaultSettings.storageOverProvisioningPercentage
+        label: Storage Over Provisioning Percentage
+        description: >-
+          Percentage of storage that can be allocated relative to hard drive capacity. The default value is 100.
+        group: Longhorn Default Settings
+        type: int
+        min: 0
+        default: 100
+      - variable: defaultSettings.storageMinimalAvailablePercentage
+        label: Storage Minimal Available Percentage
+        description: >-
+          If the minimum available disk capacity exceeds the actual percentage of available disk capacity, the disk becomes unschedulable until more space is freed up. By default, 25.
+        group: Longhorn Default Settings
+        type: int
+        min: 0
+        max: 100
+        default: 25
+      - variable: defaultSettings.storageReservedPercentageForDefaultDisk
+        label: Storage Reserved Percentage For Default Disk
+        description: >-
+          The reserved percentage specifies the percentage of disk space that will not be allocated to the default disk on each new Longhorn node.
+        group: Longhorn Default Settings
+        type: int
+        min: 0
+        max: 100
+        default: 30
+      - variable: defaultSettings.upgradeChecker
+        label: Enable Upgrade Checker
+        description: >-
+          Upgrade Checker that periodically checks for new Longhorn versions. When a new version is available, a notification appears on the Longhorn UI. This setting is enabled by default.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'true'
+      - variable: defaultSettings.upgradeResponderURL
+        label: Upgrade Responder URL
+        description: >-
+          The Upgrade Responder sends a notification whenever a new Longhorn version that you can upgrade to becomes available. The default value is "https://longhorn-upgrade-responder.rancher.io/v1/checkupgrade".
+        group: Longhorn Default Settings
+        type: string
+        default: 'https://longhorn-upgrade-responder.rancher.io/v1/checkupgrade'
+      - variable: defaultSettings.managerUrl
+        label: Manager URL
+        description: >-
+          The external URL used to access the Longhorn Manager API. When set, this URL is returned in API responses (the actions and links fields) instead of the internal pod IP. This is useful when accessing the API through Ingress or Gateway API HTTPRoute. Format: scheme://host[:port] (for example, https://longhorn.example.com or https://longhorn.example.com:8443). Leave it empty to use the default behavior.
+        group: Longhorn Default Settings
+        type: string
+        default: ''
+      - variable: defaultSettings.defaultReplicaCount
+        label: Default Replica Count
+        description: >-
+          Default number of replicas for volumes created using the Longhorn UI. For Kubernetes configuration, modify the `numberOfReplicas` field in the StorageClass.
+        group: Longhorn Default Settings
+        type: string
+        default: '{"v1":"3","v2":"3"}'
+      - variable: defaultSettings.defaultLonghornStaticStorageClass
+        label: Default Longhorn Static StorageClass Name
+        description: >-
+          Default name of Longhorn Static StorageClass. The "storageClassName" is assigned to PVs and PVCs that are created for an existing Longhorn volume. The "storageClassName" can also be used as a label, so it is possible to use a Longhorn StorageClass to bind a workload to an existing PV without creating a Kubernetes StorageClass object. The "storageClassName" needs to be an existing StorageClass. The default value is "longhorn-static".
+        group: Longhorn Default Settings
+        type: string
+        default: longhorn-static
+      - variable: defaultSettings.failedBackupTTL
+        label: Failed Backup Time to Live
+        description: >-
+          Number of minutes that Longhorn keeps a failed backup resource. When the value is "0", automatic deletion is disabled.
+        group: Longhorn Default Settings
+        type: int
+        min: 0
+        default: 1440
+      - variable: defaultSettings.backupExecutionTimeout
+        label: Backup Execution Timeout
+        description: >-
+          Number of minutes that Longhorn allows for the backup execution. The default value is "1".
+        group: Longhorn Default Settings
+        type: int
+        min: 1
+        default: 1
+      - variable: defaultSettings.restoreVolumeRecurringJobs
+        label: Restore Volume Recurring Jobs
+        description: >-
+          Restore recurring jobs from the backup volume on the backup target and create recurring jobs if not exist during a backup restoration.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'false'
+      - variable: defaultSettings.recurringSuccessfulJobsHistoryLimit
+        label: Cronjob Successful Jobs History Limit
+        description: >-
+          This setting specifies how many successful backup or snapshot job histories should be retained. History will not be retained if the value is 0.
+        group: Longhorn Default Settings
+        type: int
+        min: 0
+        default: 1
+      - variable: defaultSettings.recurringFailedJobsHistoryLimit
+        label: Cronjob Failed Jobs History Limit
+        description: >-
+          Maximum number of failed recurring backup and snapshot jobs to be retained. When the value is "0", a history of failed recurring jobs is not retained.
+        group: Longhorn Default Settings
+        type: int
+        min: 0
+        default: 1
+      - variable: defaultSettings.recurringJobMaxRetention
+        label: Maximum Retention Number for Recurring Job
+        description: Maximum number of snapshots or backups to be retained.
+        group: Longhorn Default Settings
+        type: int
+        default: 100
+      - variable: defaultSettings.supportBundleFailedHistoryLimit
+        label: SupportBundle Failed History Limit
+        description: >-
+          This setting specifies how many failed support bundles can exist in the cluster. Set this value to **0** to have Longhorn automatically purge all failed support bundles.
+        group: Longhorn Default Settings
+        type: int
+        min: 0
+        default: 1
+      - variable: defaultSettings.autoSalvage
+        label: Automatic salvage
+        description: >-
+          Setting that allows Longhorn to automatically salvage volumes when all replicas become faulty (for example, when the network connection is interrupted). Longhorn determines which replicas are usable and then uses these replicas for the volume. This setting is enabled by default.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'true'
+      - variable: defaultSettings.autoDeletePodWhenVolumeDetachedUnexpectedly
+        label: >-
+          Automatically Delete Workload Pod when The Volume Is Detached Unexpectedly
+        description: >-
+          Setting that allows Longhorn to automatically delete a workload pod that is managed by a controller (for example, daemonset) whenever a Longhorn volume is detached unexpectedly (for example, during Kubernetes upgrades). After deletion, the controller restarts the pod and then Kubernetes handles volume reattachment and remounting.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'true'
+      - variable: defaultSettings.blacklistForAutoDeletePodWhenVolumeDetachedUnexpectedly
+        label: >-
+          Blacklist for Automatically Delete Workload Pod when The Volume Is Detached Unexpectedly
+        description: >-
+          Blacklist of controller api/kind values for the setting Automatically Delete Workload Pod when the Volume Is Detached Unexpectedly. If a workload pod is managed by a controller whose api/kind is listed in this blacklist, Longhorn will not automatically delete the pod when its volume is unexpectedly detached. Multiple controller api/kind entries can be specified, separated by semicolons. For example: `apps/StatefulSet;apps/DaemonSet`. Note that the controller api/kind is case sensitive and must exactly match the api/kind in the workload pod's owner reference.
+        group: Longhorn Default Settings
+        type: string
+        default: null
+      - variable: defaultSettings.disableSchedulingOnCordonedNode
+        label: Disable Scheduling On Cordoned Node
+        description: >-
+          Setting that prevents Longhorn Manager from scheduling replicas on a cordoned Kubernetes node. This setting is enabled by default.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'true'
+      - variable: defaultSettings.replicaZoneSoftAntiAffinity
+        label: Replica Zone Level Soft Anti-Affinity
+        description: >-
+          Allow scheduling new Replicas of Volume to the Nodes in the same Zone as existing healthy Replicas. Nodes don't belong to any Zone will be treated as in the same Zone. Notice that Longhorn relies on label `topology.kubernetes.io/zone=<Zone name of the node>` in the Kubernetes node object to identify the zone. By, default true.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'true'
+      - variable: defaultSettings.replicaDiskSoftAntiAffinity
+        label: Replica Disk Level Soft Anti-Affinity
+        description: >-
+          Allow scheduling on disks with existing healthy replicas of the same volume. By default, true.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'true'
+      - variable: defaultSettings.allowEmptyNodeSelectorVolume
+        label: Allow Empty Node Selector Volume
+        description: >-
+          Setting that allows scheduling of empty node selector volumes to any node.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'true'
+      - variable: defaultSettings.allowEmptyDiskSelectorVolume
+        label: Allow Empty Disk Selector Volume
+        description: >-
+          Setting that allows scheduling of empty disk selector volumes to any disk.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'true'
+      - variable: defaultSettings.nodeDownPodDeletionPolicy
+        label: Pod Deletion Policy When Node is Down
+        description: >-
+          Policy that defines the action Longhorn takes when a volume is stuck with a StatefulSet or Deployment pod on a node that failed.
+        group: Longhorn Default Settings
+        type: enum
+        options:
+          - do-nothing
+          - delete-statefulset-pod
+          - delete-deployment-pod
+          - delete-both-statefulset-and-deployment-pod
+        default: do-nothing
+      - variable: defaultSettings.nodeDrainPolicy
+        label: Node Drain Policy
+        description: >-
+          Policy that defines the action Longhorn takes when a node with the last healthy replica of a volume is drained.
+        group: Longhorn Default Settings
+        type: enum
+        options:
+          - block-for-eviction
+          - block-for-eviction-if-contains-last-replica
+          - block-if-contains-last-replica
+          - allow-if-replica-is-stopped
+          - always-allow
+        default: block-if-contains-last-replica
+      - variable: defaultSettings.detachManuallyAttachedVolumesWhenCordoned
+        label: Detach Manually Attached Volumes When Cordoned
+        description: >-
+          Setting that allows automatic detaching of manually-attached volumes when a node is cordoned.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'false'
+      - variable: defaultSettings.priorityClass
+        label: Priority Class
+        description: >-
+          PriorityClass for system-managed Longhorn components. This setting can help prevent Longhorn components from being evicted under Node Pressure. Longhorn system contains user deployed components (E.g, Longhorn manager, Longhorn driver, Longhorn UI) and system managed components (E.g, instance manager, engine image, CSI driver, etc.) Note that this will be applied to Longhorn user-deployed components by default if there are no priority class values set yet, such as `longhornManager.priorityClass`. WARNING: DO NOT CHANGE THIS SETTING WITH ATTACHED VOLUMES.
+        group: Longhorn Default Settings
+        type: string
+        default: longhorn-critical
+      - variable: defaultSettings.replicaReplenishmentWaitInterval
+        label: Replica Replenishment Wait Interval
+        description: >-
+          The interval in seconds determines how long Longhorn will at least wait to reuse the existing data on a failed replica rather than directly creating a new replica for a degraded volume.
+        group: Longhorn Default Settings
+        type: int
+        min: 0
+        default: 600
+      - variable: defaultSettings.concurrentReplicaRebuildPerNodeLimit
+        label: Concurrent Replica Rebuild Per Node Limit
+        description: >-
+          Maximum number of replicas that can be concurrently rebuilt on each node. **Caution**: [1] This setting replaces "Disable Replica Rebuild". Instead of delaying replica startup, Longhorn skips replica object replenishment to limit the number of concurrently rebuilding replicas. [2] When the value is "0", the eviction and data locality features do not work, but ongoing replica rebuilding and backup/restoration operations should remain unaffected.
+        group: Longhorn Default Settings
+        type: int
+        min: 0
+        default: 5
+      - variable: defaultSettings.rebuildConcurrentSyncLimit
+        label: Rebuild Concurrent Sync Limit
+        description: >-
+          Maximum number of file synchronization operations that can run concurrently during a single replica rebuild. Right now, it's for v1 data engine only.
+        group: Longhorn Default Settings
+        type: int
+        min: 1
+        max: 5
+        default: 1
+      - variable: defaultSettings.concurrentVolumeBackupRestorePerNodeLimit
+        label: Concurrent Volume Backup Restore Per Node Limit
+        description: >-
+          Maximum number of volumes that can be concurrently restored on each node using a backup. When the value is "0", restoration of volumes using a backup is disabled.
+        group: Longhorn Default Settings
+        type: int
+        min: 0
+        default: 5
+      - variable: defaultSettings.disableRevisionCounter
+        label: Disable Revision Counter
+        description: >-
+          Setting that disables the revision counter and thereby prevents Longhorn from tracking all write operations to a volume. When salvaging a volume, Longhorn uses properties of the "volume-head-xxx.img" file (the last file size and the last time the file was modified) to select the replica to be used for volume recovery. This setting applies only to volumes created using the Longhorn UI.
+        group: Longhorn Default Settings
+        type: string
+        default: '{"v1":"true"}'
+      - variable: defaultSettings.systemManagedPodsImagePullPolicy
+        label: System Managed Pod Image Pull Policy
+        description: >-
+          Image pull policy for system-managed pods, such as Instance Manager, engine images, and CSI Driver. Changes to the image pull policy are applied only after the system-managed pods restart.
+        group: Longhorn Default Settings
+        type: enum
+        options:
+          - if-not-present
+          - always
+          - never
+        default: if-not-present
+      - variable: defaultSettings.allowVolumeCreationWithDegradedAvailability
+        label: Allow Volume Creation with Degraded Availability
+        description: >-
+          Setting that allows you to create and attach a volume without having all replicas scheduled at the time of creation.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'true'
+      - variable: defaultSettings.autoCleanupSystemGeneratedSnapshot
+        label: Automatically Cleanup System Generated Snapshot
+        description: >-
+          Setting that allows Longhorn to automatically clean up the system-generated snapshot after replica rebuilding is completed.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'true'
+      - variable: defaultSettings.autoCleanupRecurringJobBackupSnapshot
+        label: Automatically Cleanup Recurring Job Backup Snapshot
+        description: >-
+          Setting that allows Longhorn to automatically clean up the snapshot generated by a recurring backup job.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'true'
+      - variable: defaultSettings.concurrentAutomaticEngineUpgradePerNodeLimit
+        label: Concurrent Automatic Engine Upgrade Per Node Limit
+        description: >-
+          Maximum number of engines that are allowed to concurrently upgrade on each node after Longhorn Manager is upgraded. When the value is "0", Longhorn does not automatically upgrade volume engines to the new default engine image version.
+        group: Longhorn Default Settings
+        type: int
+        min: 0
+        default: 0
+      - variable: defaultSettings.backingImageCleanupWaitInterval
+        label: Backing Image Cleanup Wait Interval
+        description: >-
+          Number of minutes that Longhorn waits before cleaning up the backing image file when no replicas in the disk are using it.
+        group: Longhorn Default Settings
+        type: int
+        min: 0
+        default: 60
+      - variable: defaultSettings.backingImageRecoveryWaitInterval
+        label: Backing Image Recovery Wait Interval
+        description: >-
+          Number of seconds that Longhorn waits before downloading a backing image file again when the status of all image disk files changes to "failed" or "unknown".
+        group: Longhorn Default Settings
+        type: int
+        min: 0
+        default: 300
+      - variable: defaultSettings.guaranteedInstanceManagerCPU
+        label: Guaranteed Instance Manager CPU
+        description: >-
+          Percentage of the total allocatable CPU resources on each node to be reserved for each Instance Manager pod when the V1 Data Engine is enabled. You can specify a floating point value between "0" and "40" to accommodate the possible number of new Instance Manager pods during upgrades. The default value is "12". **Caution**: [1] When the value is "0", CPU requests are removed from the spec of Instance Manager pods. [2] A new set of Instance Manager pods must be deployed when Longhorn is upgraded. If the available CPUs are not sufficient for the new pods, you must detach the volumes using the oldest Instance Manager pods so that Longhorn can automatically clean up the old pods and release the CPU resources. Once completed, the new pods with the latest Instance Manager image are launched. [3] This global setting is not applied to nodes with a specified value for the "InstanceManagerCPURequest" field. [4] After this setting is configured, Instance Manager pods on all nodes that use this setting are automatically restarted. **Do not change this setting while volumes are still attached. [5] or the v2 Data Engine, the spdk_tgt process inside each instance manager pod uses one or more dedicated CPU cores. Setting a minimum CPU usage is critical to maintaining stability during periods of high node load.**
+        group: Longhorn Default Settings
+        type: string
+        default: '{"v1":"12","v2":"12"}'
+      - variable: defaultSettings.logLevel
+        label: Log Level
+        description: >-
+          Log levels that indicate the type and severity of logs in Longhorn Manager. The default value is "Info". (Options: "Panic", "Fatal", "Error", "Warn", "Info", "Debug", "Trace")
+        group: Longhorn Default Settings
+        type: string
+        default: Info
+      - variable: defaultSettings.disableSnapshotPurge
+        label: Disable Snapshot Purge
+        description: >-
+          Setting that temporarily prevents all attempts to purge volume snapshots.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'false'
+      - variable: defaultSettings.freezeFilesystemForSnapshot
+        description: >-
+          Setting that freezes the filesystem on the root partition before a snapshot is created.
+        group: Longhorn Default Settings
+        type: string
+        default: '{"v1":"false"}'
+      - variable: defaultSettings.kubernetesClusterAutoscalerEnabled
+        label: Kubernetes Cluster Autoscaler Enabled (Experimental)
+        description: >-
+          Setting that notifies Longhorn that the cluster is using the Kubernetes Cluster Autoscaler. **Caution**: Replica rebuilding may consume significant resources if the Kubernetes Cluster Autoscaler removes nodes with reusable replicas.
+        group: Longhorn Default Settings
+        type: boolean
+        default: false
+      - variable: defaultSettings.orphanResourceAutoDeletion
+        label: Orphaned Data Cleanup
+        description: >-
+          Enables Longhorn to automatically delete orphaned resources and their associated data or processes (e.g., stale replicas). Orphaned resources on failed or unknown nodes are not automatically cleaned up. You need to specify the resource types to be deleted using a semicolon-separated list (e.g., `replica-data;instance`). Valid resource types: `replica-data`, `instance`.
+        group: Longhorn Default Settings
+        type: string
+        default: null
+      - variable: defaultSettings.orphanResourceAutoDeletionGracePeriod
+        label: Orphaned Data Cleanup
+        description: >-
+          Specifies the wait time, in seconds, before Longhorn automatically deletes an orphaned Custom Resource (CR) and its associated resources. Note that if a user manually deletes an orphaned CR, the deletion occurs immediately and does not respect this grace period.
+        group: Longhorn Default Settings
+        type: int
+        default: '300'
+      - variable: defaultSettings.storageNetwork
+        label: Storage Network
+        description: >-
+          Longhorn uses the storage network for in-cluster data traffic. Leave this blank to use the Kubernetes cluster network. **Caution**: This setting should change after all volumes are detached because some Longhorn component pods must be recreated to apply the setting. You cannot modify this setting while volumes are still attached.
+        group: Longhorn Default Settings
+        type: string
+        default: null
+      - variable: defaultSettings.EndpointNetworkForRWXVolume
+        label: Endpoint Network For RWX Volume
+        description: >-
+          Specifies a dedicated network for mounting RWX (ReadWriteMany) volumes. Leave this blank to use the default Kubernetes cluster network. **Caution**: This setting should change after all RWX volumes are detached because some Longhorn component pods must be recreated to apply the setting. You cannot modify this setting while RWX volumes are still attached.
+        group: Longhorn Default Settings
+        type: string
+        default: null
+      - variable: defaultSettings.taintToleration
+        label: Taint Toleration
+        description: >-
+          Taint or toleration for system-managed Longhorn components. Specify values using a semicolon-separated list in `kubectl taint` syntax (Example: key1=value1:effect; key2=value2:effect). **Caution**: This setting should change after all volumes are detached because some Longhorn component pods must be recreated to apply the setting. You cannot modify this setting while volumes are still attached.
+        group: Longhorn Default Settings
+        type: string
+        default: null
+      - variable: defaultSettings.systemManagedComponentsNodeSelector
+        label: System Managed Components NodeSelector
+        description: >-
+          Node selector for system-managed Longhorn components.. **Caution**: This setting should change after all volumes are detached because some Longhorn component pods must be recreated to apply the setting. You cannot modify this setting while volumes are still attached.
+        group: Longhorn Default Settings
+        type: string
+        default: null
+      - variable: defaultSettings.systemManagedCSIComponentsResourceLimits
+        label: System Managed CSI Components Resource Limits
+        description: >-
+          Resource limits for system managed CSI components.  This setting allows you to configure CPU and memory requests/limits for CSI attacher, provisioner, resizer, snapshotter, and plugin components. Supported components: csi-attacher, csi-provisioner, csi-resizer, csi-snapshotter, longhorn-csi-plugin, node-driver-registrar, longhorn-liveness-probe. Notice that changing resource limits will cause CSI components to restart, which may temporarily affect volume provisioning and attach/detach operations until the components are ready. The value should be a JSON object with component names as keys and ResourceRequirements as values.
+        group: Longhorn Default Settings
+        type: string
+        default: null
+      - variable: defaultSettings.deletingConfirmationFlag
+        label: Deleting Confirmation Flag
+        description: Flag that prevents accidental uninstallation of Longhorn.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'false'
+      - variable: defaultSettings.engineReplicaTimeout
+        label: Timeout between Engine and Replica
+        description: >-
+          Timeout between the Longhorn Engine and replicas. Specify a value between "8" and "30" seconds. The default value is "8".
+        group: Longhorn Default Settings
+        type: string
+        default: '{"v1":"8","v2":"8"}'
+      - variable: defaultSettings.snapshotDataIntegrity
+        label: Snapshot Data Integrity
+        description: >-
+          This setting allows users to enable or disable snapshot hashing and data integrity checking.
+        group: Longhorn Default Settings
+        type: enum
+        options:
+          - enabled
+          - fast-check
+          - disabled
+        default: disabled
+      - variable: >-
+          defaultSettings.snapshotDataIntegrityImmediateCheckAfterSnapshotCreation
+        label: Immediate Snapshot Data Integrity Check After Creating a Snapshot
+        description: >-
+          Hashing snapshot disk files impacts the performance of the system. The immediate snapshot hashing and checking can be disabled to minimize the impact after creating a snapshot.
+        group: Longhorn Default Settings
+        type: string
+        default: '{"v1":"false","v2":"false"}'
+      - variable: defaultSettings.snapshotDataIntegrityCronjob
+        label: Snapshot Data Integrity Check CronJob
+        description: >-
+          Unix-cron string format. The setting specifies when Longhorn checks the data integrity of snapshot disk files.
+        group: Longhorn Default Settings
+        type: string
+        default: '{"v1":"0 0 */7 * *","v2":"0 0 */7 * *"}'
+      - variable: defaultSettings.removeSnapshotsDuringFilesystemTrim
+        label: Remove Snapshots During Filesystem Trim
+        description: >-
+          This setting allows Longhorn filesystem trim feature to automatically mark the latest snapshot and its ancestors as removed and stops at the snapshot containing multiple children.
+        group: Longhorn Default Settings
+        type: boolean
+        default: 'false'
+      - variable: defaultSettings.fastReplicaRebuildEnabled
+        label: Fast Replica Rebuild Enabled
+        description: >-
+          Setting that allows fast rebuilding of replicas using the checksum of snapshot disk files. Before enabling this setting, you must set the snapshot-data-integrity value to "enable" or "fast-check".
+        group: Longhorn Default Settings
+        type: string
+        default: '{"v1":"true","v2":"true"}'
+      - variable: defaultSettings.replicaFileSyncHttpClientTimeout
+        label: Timeout of HTTP Client to Replica File Sync Server
+        description: >-
+          In seconds. The setting specifies the HTTP client timeout to the file sync server.
+        group: Longhorn Default Settings
+        type: int
+        default: '30'
+      - variable: defaultSettings.longGRPCTimeOut
+        label: Long gRPC Timeout
+        description: >-
+          Number of seconds that Longhorn allows for the completion of replica rebuilding and snapshot cloning operations.
+        group: Longhorn Default Settings
+        type: int
+        default: '86400'
+      - variable: defaultSettings.backupCompressionMethod
+        label: Backup Compression Method
+        description: Setting that allows you to specify a backup compression method.
+        group: Longhorn Default Settings
+        type: string
+        default: lz4
+      - variable: defaultSettings.backupConcurrentLimit
+        label: Backup Concurrent Limit Per Backup
+        description: >-
+          Maximum number of worker threads that can concurrently run for each backup.
+        group: Longhorn Default Settings
+        type: int
+        min: 1
+        default: 2
+      - variable: defaultSettings.backupBlockSize
+        label: Backup Block Size
+        description: >-
+          Specifies the default backup block size, in MiB, used when creating a new volume. Supported values are 2 or 16.
+        group: Longhorn Default Settings
+        type: enum
+        options:
+          - '2'
+          - '16'
+        default: '2'
+      - variable: defaultSettings.restoreConcurrentLimit
+        label: Restore Concurrent Limit Per Backup
+        description: >-
+          This setting controls how many worker threads per restore concurrently.
+        group: Longhorn Default Settings
+        type: int
+        min: 1
+        default: 2
+      - variable: defaultSettings.allowCollectingLonghornUsageMetrics
+        label: Allow Collecting Longhorn Usage Metrics
+        description: >-
+          Setting that allows Longhorn to periodically collect anonymous usage data for product improvement purposes. Longhorn sends collected data to the [Upgrade Responder](https://github.com/longhorn/upgrade-responder) server, which is the data source of the Longhorn Public Metrics Dashboard (https://metrics.longhorn.io). The Upgrade Responder server does not store data that can be used to identify clients, including IP addresses.
+        group: Longhorn Default Settings
+        type: boolean
+        default: true
+      - variable: defaultSettings.v1DataEngine
+        label: V1 Data Engine
+        description: Setting that allows you to enable the V1 Data Engine.
+        group: Longhorn V1 Data Engine Settings
+        type: boolean
+        default: true
+      - variable: defaultSettings.v2DataEngine
+        label: V2 Data Engine
+        description: >-
+          Setting that allows you to enable the V2 Data Engine, which is based on the Storage Performance Development Kit (SPDK). The V2 Data Engine is an experimental feature and should not be used in production environments. **Caution**: [1] **Do not modify this setting while volumes are still attached.** [2] When the V2 Data Engine is enabled, each Instance Manager pod for the V2 Data Engine uses 1 CPU core. The high CPU usage is caused by `spdk_tgt`, a process running in each Instance Manager pod that handles input/output (IO) operations and requires intensive polling. `spdk_tgt` consumes 100% of a dedicated CPU core to efficiently manage and process the IO requests, ensuring optimal performance and responsiveness for storage operations.
+        group: Longhorn V2 Data Engine (Experimental Feature) Settings
+        type: boolean
+        default: false
+      - variable: defaultSettings.dataEngineHugepageEnabled
+        label: V2 Data Engine
+        description: >-
+          Applies only to the V2 Data Engine. Enables hugepages for the Storage Performance Development Kit (SPDK) target daemon. If disabled, legacy memory is used. Allocation size is set via the Data Engine Memory Size setting.
+        group: Longhorn V2 Data Engine (Experimental Feature) Settings
+        type: string
+        default: '{"v2":"true"}'
+      - variable: defaultSettings.dataEngineMemorySize
+        label: V2 Data Engine
+        description: >-
+          Applies only to the V2 Data Engine. Specifies the memory size, in MiB, allocated to the Storage Performance Development Kit (SPDK) target daemon. When hugepage is enabled, this defines the hugepage size; when legacy memory is used, hugepage is disabled.
+        group: Longhorn V2 Data Engine (Experimental Feature) Settings
+        type: string
+        default: '{"v2":"2048"}'
+      - variable: defaultSettings.dataEngineLogLevel
+        label: Data Engine Log Level
+        description: >-
+          Applies only to the V2 Data Engine. Specifies the log level for the Storage Performance Development Kit (SPDK) target daemon. Supported values are: Error, Warning, Notice, Info, and Debug. The default is Notice.
+        group: Longhorn V2 Data Engine (Experimental Feature) Settings
+        type: string
+        default: '{"v2":"Notice"}'
+      - variable: defaultSettings.dataEngineLogFlags
+        label: Data Engine Log Flags
+        description: >-
+          Applies only to the V2 Data Engine. Specifies the log flags for the Storage Performance Development Kit (SPDK) target daemon.
+        group: Longhorn V2 Data Engine (Experimental Feature) Settings
+        type: string
+        default: '{"v2":""}'
+      - variable: defaultSettings.autoCleanupSnapshotWhenDeleteBackup
+        label: Auto Cleanup Snapshot When Delete Backup
+        description: >-
+          Setting that automatically cleans up the snapshot when the backup is deleted.
+        group: Longhorn Default Settings
+        type: boolean
+        default: false
+      - variable: defaultSettings.autoCleanupSnapshotAfterOnDemandBackupCompleted
+        label: Auto Cleanup Snapshot After On-Demand Backup Completed
+        description: >-
+          Setting that automatically cleans up the snapshot after the on-demand backup is completed.
+        group: Longhorn Default Settings
+        type: boolean
+        default: false
+      - variable: defaultSettings.rwxVolumeFastFailover
+        label: RWX Volume Fast Failover (Experimental)
+        description: >-
+          Setting that allows Longhorn to detect node failure and immediately migrate affected RWX volumes.
+        group: Longhorn Default Settings
+        type: boolean
+        default: false
+      - variable: defaultSettings.offlineReplicaRebuilding
+        label: Offline Replica Rebuilding
+        description: >-
+          Enables automatic rebuilding of degraded replicas while the volume is detached. This setting only takes effect if the individual volume setting is set to `ignored` or `enabled`.
+        group: Longhorn Default Settings
+        type: string
+        default: '{"v1":"false","v2":"false"}'
+      - variable: defaultSettings.dataEngineCPUMask
+        label: Data Engine CPU Mask
+        description: >-
+          Applies only to the V2 Data Engine. Specifies the CPU cores on which the Storage Performance Development Kit (SPDK) target daemon runs. The daemon is deployed in each Instance Manager pod. Ensure that the number of assigned cores does not exceed the guaranteed Instance Manager CPUs for the V2 Data Engine.
+        group: Longhorn Default Settings
+        type: string
+        default: '{"v2":"0x1"}'
+      - variable: defaultSettings.replicaRebuildingBandwidthLimit
+        label: Replica Rebuilding Bandwidth Limit
+        description: >-
+          Applies only to the V2 Data Engine. Specifies the default write bandwidth limit, in megabytes per second (MB/s), for volume replica rebuilding. If this value is set to 0, there will be no write bandwidth limitation. Individual volumes can override this setting by specifying their own rebuilding bandwidth limit.
+        group: Longhorn Default Settings
+        type: string
+        default: '{"v2":"0"}'
+      - variable: defaultSettings.instanceManagerPodLivenessProbeTimeout
+        label: Instance Manager Pod Liveness Probe Timeout
+        description: >-
+          In seconds. The setting specifies the timeout for the instance manager pod liveness probe. The default value is 10 seconds.
+        group: Longhorn Default Settings
+        type: int
+        min: 1
+        max: 60
+        default: 10
+      - variable: defaultSettings.snapshotHeavyTaskConcurrentLimit
+        label: Snapshot Heavy Task Concurrent Limit
+        description: >-
+          Setting that controls how many snapshot heavy task operations (such as purge and clone) can run concurrently per node. This is a best-effort mechanism: due to the distributed nature of the system, temporary oversubscription may occur. The limiter reduces worst-case overload but does not guarantee perfect enforcement.
+        group: Longhorn Default Settings
+        type: int
+        min: 0
+        default: 5
+      - variable: defaultSettings.nodeDiskHealthMonitoring
+        label: Node Disk Health Monitoring
+        description: >-
+          Controls whether Longhorn monitors and records health information for node disks. When disabled, disk health checks and status updates are skipped.
+        group: Longhorn Default Settings
+        type: boolean
+        default: true
+  - variable: persistence.defaultClass
+    default: 'true'
+    description: Setting that allows you to specify the default Longhorn StorageClass.
+    label: Default Storage Class
+    group: Longhorn Storage Class Settings
+    required: true
+    type: boolean
+    subquestions: []
+  - variable: persistence.reclaimPolicy
+    label: Storage Class Retain Policy
+    description: >-
+      Reclaim policy that provides instructions for handling of a volume after its claim is released. (Options: "Retain", "Delete")
+    group: Longhorn Storage Class Settings
+    required: true
+    type: enum
+    options:
+      - Delete
+      - Retain
+    default: Delete
+    subquestions: []
+  - variable: persistence.volumeBindingMode
+    label: Storage Class Volume Binding Mode
+    description: >-
+      VolumeBindingMode controls when volume binding and dynamic provisioning should occur. (Options: "Immediate", "WaitForFirstConsumer") (Defaults to "Immediate")
+    group: Longhorn Storage Class Settings
+    required: true
+    type: enum
+    options:
+      - Immediate
+      - WaitForFirstConsumer
+    default: Immediate
+    subquestions: []
+  - variable: persistence.defaultFsType
+    label: Storage Class Filesystem Type
+    description: Filesystem type of the default Longhorn StorageClass
+    group: Longhorn Storage Class Settings
+    type: enum
+    options:
+      - xfs
+      - ext4
+    default: ext4
+    subquestions: []
+  - variable: persistence.disableRevisionCounter
+    label: Default Storage Class Disable Revision Counter
+    description: >-
+      Setting that disables the revision counter and thereby prevents Longhorn from tracking all write operations to a volume. When salvaging a volume, Longhorn uses properties of the volume-head-xxx.img file (the last file size and the last time the file was modified) to select the replica to be used for volume recovery. (Options: "true", "false")
+    group: Longhorn Storage Class Settings
+    required: true
+    type: enum
+    options:
+      - 'true'
+      - 'false'
+    default: 'true'
+    subquestions: []
+  - variable: persistence.defaultClassReplicaCount
+    description: Replica count of the default Longhorn StorageClass.
+    label: Default Storage Class Replica Count
+    group: Longhorn Storage Class Settings
+    type: int
+    min: 1
+    max: 10
+    default: 3
+    subquestions: []
+  - variable: persistence.defaultDataLocality
+    description: >-
+      Data locality of the default Longhorn StorageClass. (Options: "disabled", "best-effort")
+    label: Default Storage Class Data Locality
+    group: Longhorn Storage Class Settings
+    type: enum
+    options:
+      - disabled
+      - best-effort
+    default: disabled
+    subquestions: []
+  - variable: persistence.recurringJobSelector.enable
+    description: >-
+      Setting that allows you to enable the recurring job selector for a Longhorn StorageClass.
+    group: Longhorn Storage Class Settings
+    label: Enable Storage Class Recurring Job Selector
+    type: boolean
+    default: false
+    show_subquestion_if: true
+    subquestions:
+      - variable: persistence.recurringJobSelector.jobList
+        description: >-
+          Recurring job selector for a Longhorn StorageClass. Ensure that quotes are used correctly when specifying job parameters. (Example: `[{"name":"backup", "isGroup":true}]`)
+        label: Storage Class Recurring Job Selector List
+        group: Longhorn Storage Class Settings
+        type: string
+        default: null
+  - variable: persistence.defaultDiskSelector.enable
+    description: >-
+      Setting that allows you to enable the disk selector for the default Longhorn StorageClass.
+    group: Longhorn Storage Class Settings
+    label: Enable Storage Class Disk Selector
+    type: boolean
+    default: false
+    show_subquestion_if: true
+    subquestions:
+      - variable: persistence.defaultDiskSelector.selector
+        label: Storage Class Disk Selector
+        description: >-
+          Disk selector for the default Longhorn StorageClass. Longhorn uses only disks with the specified tags for storing volume data. (Examples: "nvme,sata")
+        group: Longhorn Storage Class Settings
+        type: string
+        default: null
+  - variable: persistence.defaultNodeSelector.enable
+    description: >-
+      Setting that allows you to enable the node selector for the default Longhorn StorageClass.
+    group: Longhorn Storage Class Settings
+    label: Enable Storage Class Node Selector
+    type: boolean
+    default: false
+    show_subquestion_if: true
+    subquestions:
+      - variable: persistence.defaultNodeSelector.selector
+        label: Storage Class Node Selector
+        description: >-
+          Node selector for the default Longhorn StorageClass. Longhorn uses only nodes with the specified tags for storing volume data. (Examples: "storage,fast")
+        group: Longhorn Storage Class Settings
+        type: string
+        default: null
+  - variable: persistence.backingImage.enable
+    description: Setting that allows you to use a backing image in a Longhorn StorageClass.
+    group: Longhorn Storage Class Settings
+    label: Default Storage Class Backing Image
+    type: boolean
+    default: false
+    show_subquestion_if: true
+    subquestions:
+      - variable: persistence.backingImage.name
+        description: >-
+          Backing image to be used for creating and restoring volumes in a Longhorn StorageClass. When no backing images are available, specify the data source type and parameters that Longhorn can use to create a backing image.
+        label: Storage Class Backing Image Name
+        group: Longhorn Storage Class Settings
+        type: string
+        default: null
+      - variable: persistence.backingImage.expectedChecksum
+        description: >-
+          Expected SHA-512 checksum of a backing image used in a Longhorn StorageClass. **Caution** [1] This field is useful only if the backing image name is specified. [2] Specifying a checksum is not recommended when the data source type is \"export-from-volume\".
+        label: Storage Class Backing Image Expected SHA512 Checksum
+        group: Longhorn Storage Class Settings
+        type: string
+        default: null
+      - variable: persistence.backingImage.dataSourceType
+        description: >-
+          Data source type of a backing image used in a Longhorn StorageClass. If the backing image exists in the cluster, Longhorn uses this setting to verify the image. If the backing image does not exist, Longhorn creates one using the specified data source type. **Caution** [1] This field is useful only if the backing image name is specified. [2] Backing images with data source type \"upload\" are best created using the Longhorn UI. Uploading requires sending file data to Longhorn after object creation, which can be complicated when performed manually.
+        label: Storage Class Backing Image Data Source Type
+        group: Longhorn Storage Class Settings
+        type: enum
+        options:
+          - ''
+          - download
+          - upload
+          - export-from-volume
+        default: ''
+      - variable: persistence.backingImage.dataSourceParameters
+        description: >-
+          Data source parameters of a backing image used in a Longhorn StorageClass. You can specify a JSON string of a map. (Example: `'{"url":"https://backing-image-example.s3-region.amazonaws.com/test-backing-image"}'`) **Caution** [1] This field is useful only if the backing image name is specified. [2] Ensure that quotes are used correctly when specifying parameters.
+        label: Storage Class Backing Image Data Source Parameters
+        group: Longhorn Storage Class Settings
+        type: string
+        default: null
+  - variable: persistence.unmapMarkSnapChainRemoved
+    description: >-
+      Setting that allows you to enable automatic snapshot removal during filesystem trim for a Longhorn StorageClass. (Options: "ignored", "enabled", "disabled")
+    label: Default Storage Class Remove Snapshots During Filesystem Trim
+    group: Longhorn Storage Class Settings
+    type: enum
+    options:
+      - ignored
+      - enabled
+      - disabled
+    default: ignored
+    subquestions: []
+  - variable: persistence.dataEngine
+    description: >-
+      Setting that allows you to specify the data engine version for the default Longhorn StorageClass. (Options: "v1", "v2")
+    label: Default Storage Class Data Engine
+    group: Longhorn Storage Class Settings
+    type: enum
+    options:
+      - v1
+      - v2
+    default: v1
+    subquestions: []
+  - variable: persistence.backupTargetName
+    description: >-
+      Setting that allows you to specify the backup target for the default Longhorn StorageClass
+    label: Default Storage Class Backup Target Name
+    group: Longhorn Storage Class Settings
+    type: string
+    default: default
+    subquestions: []
+  - variable: ingress.enabled
+    default: 'false'
+    description: Expose app using Layer 7 Load Balancer - ingress
+    type: boolean
+    group: Services and Load Balancing
+    label: Expose app using Layer 7 Load Balancer
+    show_subquestion_if: true
+    subquestions:
+      - variable: ingress.host
+        default: xip.io
+        description: Hostname of the Layer 7 load balancer.
+        type: hostname
+        required: true
+        label: Layer 7 Load Balancer Hostname
+      - variable: ingress.path
+        default: /
+        description: >-
+          Default ingress path. You can access the Longhorn UI by following the full ingress path {{host}}+{{path}}.
+        type: string
+        required: true
+        label: Ingress Path
+      - variable: ingress.pathType
+        default: ImplementationSpecific
+        description: >-
+          Path type for the ingress. (Options: "ImplementationSpecific", "Exact", "Prefix")
+        type: enum
+        options:
+          - ImplementationSpecific
+          - Exact
+          - Prefix
+        required: true
+        label: Ingress Path Type
+  - variable: httproute.enabled
+    default: 'false'
+    description: Expose app using Gateway API HTTPRoute
+    type: boolean
+    group: Services and Load Balancing
+    label: Expose app using Gateway API HTTPRoute
+    show_subquestion_if: true
+    subquestions:
+      - variable: httproute.parentRefs
+        default: '[]'
+        description: >-
+          Gateway references as JSON array. Required fields: name, namespace. Optional: group (default: gateway.networking.k8s.io), kind (default: Gateway), sectionName. Example: [{"name":"my-gateway","namespace":"default","sectionName":"https"}]
+        type: string
+        required: true
+        label: Gateway References (JSON array)
+      - variable: httproute.hostnames
+        default: '[]'
+        description: >-
+          Hostnames for HTTPRoute as JSON array (e.g., ["longhorn.example.com"])
+        type: string
+        required: true
+        label: Hostnames (JSON array)
+      - variable: httproute.path
+        default: /
+        description: >-
+          Default path for HTTPRoute. You can access the Longhorn UI by following the full path.
+        type: string
+        required: true
+        label: HTTPRoute Path
+      - variable: httproute.pathType
+        default: PathPrefix
+        description: >-
+          Path match type for HTTPRoute. (Options: "Exact", "PathPrefix")
+        type: enum
+        options:
+          - Exact
+          - PathPrefix
+        required: true
+        label: HTTPRoute Path Type
+  - variable: service.ui.type
+    default: Rancher-Proxy
+    description: >-
+      Service type for Longhorn UI. (Options: "ClusterIP", "NodePort", "LoadBalancer", "Rancher-Proxy")
+    type: enum
+    options:
+      - ClusterIP
+      - NodePort
+      - LoadBalancer
+      - Rancher-Proxy
+    label: Longhorn UI Service
+    show_if: ingress.enabled=false
+    group: Services and Load Balancing
+    show_subquestion_if: NodePort
+    subquestions:
+      - variable: service.ui.nodePort
+        default: ''
+        description: >-
+          NodePort port number for Longhorn UI. When unspecified, Longhorn selects a free port between 30000 and 32767.
+        type: int
+        min: 30000
+        max: 32767
+        show_if: service.ui.type=NodePort||service.ui.type=LoadBalancer
+        label: UI Service NodePort number
+  - variable: longhorn.default_resource
+    default: 'false'
+    description: >-
+      Customize the default resource before installing Longhorn for the first time. This option will only work if the cluster hasn't installed Longhorn.
+    label: Customize Default Resources
+    type: boolean
+    show_subquestion_if: true
+    group: Longhorn Default Resources
+    subquestions:
+      - variable: defaultBackupStore.backupTarget
+        label: Backup Target
+        description: >-
+          Endpoint used to access the backupstore. (Options: "NFS", "CIFS", "AWS", "GCP", "AZURE")
+        group: Longhorn Default Resources
+        type: string
+        default: null
+      - variable: defaultBackupStore.backupTargetCredentialSecret
+        label: Backup Target Credential Secret
+        description: Name of the Kubernetes secret associated with the backup target.
+        group: Longhorn Default Resources
+        type: string
+        default: null
+      - variable: defaultBackupStore.backupstorePollInterval
+        label: Backupstore Poll Interval
+        description: >-
+          Number of seconds that Longhorn waits before checking the backupstore for new backups. The default value is "300". When the value is "0", polling is disabled.
+        group: Longhorn Default Resources
+        type: int
+        min: 0
+        default: 300
+  - variable: enablePSP
+    default: 'false'
+    description: >-
+      Setting that allows you to enable pod security policies (PSPs) that allow privileged Longhorn pods to start. This setting applies only to clusters running Kubernetes 1.25 and earlier, and with the built-in Pod Security admission controller enabled.
+    label: Pod Security Policy
+    type: boolean
+    group: Other Settings
+    subquestions: []
+  - variable: global.cattle.windowsCluster.enabled
+    default: 'false'
+    description: Setting that allows Longhorn to run on a Rancher Windows cluster.
+    label: Rancher Windows Cluster
+    type: boolean
+    group: Other Settings
+    subquestions: []
+  - variable: networkPolicies.enabled
+    description: >-
+      Setting that allows you to enable network policies that control access to Longhorn pods. **Caution** The Rancher Proxy will work only if this feature is enabled and a custom NetworkPolicy is added.
+    group: Other Settings
+    label: Network Policies
+    default: 'false'
+    type: boolean
+    subquestions:
+      - variable: networkPolicies.type
+        label: Network Policies for Ingress
+        description: >-
+          Distribution that determines the policy for allowing access for an ingress. (Options: "k3s", "rke2", "rke1")
+        show_if: networkPolicies.enabled=true&&ingress.enabled=true
+        type: enum
+        default: rke2
+        options:
+          - rke1
+          - rke2
+          - k3s

--- a/manifests/core/longhorn/templates/NOTES.txt
+++ b/manifests/core/longhorn/templates/NOTES.txt
@@ -1,0 +1,5 @@
+Longhorn is now installed on the cluster!
+
+Please wait a few minutes for other Longhorn components such as CSI deployments, Engine Images, and Instance Managers to be initialized.
+
+Visit our documentation at https://longhorn.io/docs/

--- a/manifests/core/longhorn/templates/_helpers.tpl
+++ b/manifests/core/longhorn/templates/_helpers.tpl
@@ -1,0 +1,91 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "longhorn.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "longhorn.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{- define "longhorn.managerIP" -}}
+{{- $fullname := (include "longhorn.fullname" .) -}}
+{{- printf "http://%s-backend:9500" $fullname | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{- define "secret" }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.privateRegistry.registryUrl (printf "%s:%s" .Values.privateRegistry.registryUser .Values.privateRegistry.registryPasswd | b64enc) | b64enc }}
+{{- end }}
+
+{{- /*
+longhorn.labels generates the standard Helm labels.
+*/ -}}
+{{- define "longhorn.labels" -}}
+app.kubernetes.io/name: {{ template "longhorn.name" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- end -}}
+
+
+{{- define "system_default_registry" -}}
+{{- if .Values.global.cattle.systemDefaultRegistry -}}
+{{- .Values.global.cattle.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "registry_url" -}}
+{{- if .Values.privateRegistry.registryUrl -}}
+{{- .Values.privateRegistry.registryUrl -}}
+{{- else -}}
+{{ include "system_default_registry" . }}
+{{- end -}}
+{{- end -}}
+
+{{- /*
+ define the longhorn release namespace
+*/ -}}
+{{- define "release_namespace" -}}
+{{- if .Values.namespaceOverride -}}
+{{- .Values.namespaceOverride -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{- /*
+multiTypeSetting helper
+Input: any value (string, number, or map)
+Output: properly quoted YAML string
+*/ -}}
+{{- define "longhorn.multiTypeSetting" -}}
+  {{- $v := . -}}
+  {{- if kindIs "map" $v -}}
+    {{- $v | toJson | quote -}}
+  {{- else -}}
+    {{- $v | quote -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Optional timezone injection for all Longhorn workloads.
+When .Values.global.timezone is set, this snippet renders a TZ env var.
+*/}}
+{{- define "longhorn.timezoneEnv" -}}
+{{- if .Values.global.timezone }}
+- name: TZ
+  value: {{ .Values.global.timezone | quote }}
+{{- end }}
+{{- end -}}

--- a/manifests/core/longhorn/templates/clusterrole.yaml
+++ b/manifests/core/longhorn/templates/clusterrole.yaml
@@ -1,0 +1,89 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: longhorn-role
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch", "delete", "deletecollection"]
+- apiGroups: [""]
+  resources: ["secrets", "services", "endpoints", "configmaps", "serviceaccounts", "pods/log"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events", "persistentvolumes", "persistentvolumeclaims", "persistentvolumeclaims/status", "nodes"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets", "statefulsets", "deployments", "replicasets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["batch"]
+  resources: ["jobs", "cronjobs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["policy"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["scheduling.k8s.io"]
+  resources: ["priorityclasses"]
+  verbs: ["watch", "list"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses", "volumeattachments", "volumeattachments/status", "csinodes", "csidrivers", "csistoragecapacities"]
+  verbs: ["*"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotclasses", "volumesnapshots", "volumesnapshotcontents", "volumesnapshotcontents/status"]
+  verbs: ["*"]
+- apiGroups: ["longhorn.io"]
+  resources: ["volumes", "volumes/status", "engines", "engines/status", "replicas", "replicas/status", "settings", "settings/status",
+              "engineimages", "engineimages/status", "nodes", "nodes/status", "instancemanagers", "instancemanagers/status",
+  {{- if .Values.openshift.enabled }}
+              "engineimages/finalizers", "nodes/finalizers", "instancemanagers/finalizers",
+  {{- end }}
+              "sharemanagers", "sharemanagers/status", "backingimages", "backingimages/status",
+              "backingimagemanagers", "backingimagemanagers/status", "backingimagedatasources", "backingimagedatasources/status",
+              "backuptargets", "backuptargets/status", "backupvolumes", "backupvolumes/status", "backups", "backups/status",
+              "recurringjobs", "recurringjobs/status", "orphans", "orphans/status", "snapshots", "snapshots/status",
+              "supportbundles", "supportbundles/status", "systembackups", "systembackups/status", "systemrestores", "systemrestores/status",
+              "volumeattachments", "volumeattachments/status", "backupbackingimages", "backupbackingimages/status"]
+  verbs: ["*"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list"]
+- apiGroups: ["apiregistration.k8s.io"]
+  resources: ["apiservices"]
+  verbs: ["list", "watch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+  verbs: ["get", "list", "create", "patch", "delete"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterrolebindings", "clusterroles"]
+  verbs: ["*"]
+{{- if .Values.openshift.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: longhorn-ocp-privileged-role
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+rules:
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  resourceNames: ["anyuid", "privileged"]
+  verbs: ["use"]
+{{- end }}

--- a/manifests/core/longhorn/templates/clusterrolebinding.yaml
+++ b/manifests/core/longhorn/templates/clusterrolebinding.yaml
@@ -1,0 +1,49 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: longhorn-bind
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: longhorn-role
+subjects:
+- kind: ServiceAccount
+  name: longhorn-service-account
+  namespace: {{ include "release_namespace" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: longhorn-support-bundle
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: longhorn-support-bundle
+  namespace: {{ include "release_namespace" . }}
+{{- if .Values.openshift.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: longhorn-ocp-privileged-bind
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: longhorn-ocp-privileged-role
+subjects:
+- kind: ServiceAccount
+  name: longhorn-service-account
+  namespace: {{ include "release_namespace" . }}
+- kind: ServiceAccount
+  name: longhorn-ui-service-account
+  namespace: {{ include "release_namespace" . }}
+- kind: ServiceAccount
+  name: default  # supportbundle-agent-support-bundle uses default sa
+  namespace: {{ include "release_namespace" . }}
+{{- end }}

--- a/manifests/core/longhorn/templates/crds.yaml
+++ b/manifests/core/longhorn/templates/crds.yaml
@@ -1,129 +1,10 @@
----
-# Builtin: "helm template" does not respect --create-namespace
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: longhorn-system
----
-# Source: longhorn/templates/priorityclass.yaml
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: "longhorn-critical"
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
-description: "Ensure Longhorn pods have the highest priority to prevent any unexpected eviction by the Kubernetes scheduler under node pressure"
-globalDefault: false
-preemptionPolicy: PreemptLowerPriority
-value: 1000000000
----
-# Source: longhorn/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: longhorn-service-account
-  namespace: longhorn-system
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
----
-# Source: longhorn/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: longhorn-ui-service-account
-  namespace: longhorn-system
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
----
-# Source: longhorn/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: longhorn-support-bundle
-  namespace: longhorn-system
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
----
-# Source: longhorn/templates/default-resource.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: longhorn-default-resource
-  namespace: longhorn-system
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
-data:
-  default-resource.yaml: |-
----
-# Source: longhorn/templates/default-setting.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: longhorn-default-setting
-  namespace: longhorn-system
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
-data:
-  default-setting.yaml: |-
-    priority-class: longhorn-critical
-    disable-revision-counter: true
----
-# Source: longhorn/templates/storageclass.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: longhorn-storageclass
-  namespace: longhorn-system
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
-data:
-  storageclass.yaml: |
-    kind: StorageClass
-    apiVersion: storage.k8s.io/v1
-    metadata:
-      name: longhorn
-      annotations:
-        storageclass.kubernetes.io/is-default-class: "true"
-    provisioner: driver.longhorn.io
-    allowVolumeExpansion: true
-    reclaimPolicy: "Delete"
-    volumeBindingMode: Immediate
-    parameters:
-      numberOfReplicas: "3"
-      staleReplicaTimeout: "30"
-      fromBackup: ""
-      fsType: "ext4"
-      dataLocality: "disabled"
-      unmapMarkSnapChainRemoved: "ignored"
-      disableRevisionCounter: "true"
-      dataEngine: "v1"
-      backupTargetName: "default"
----
-# Source: longhorn/templates/crds.yaml
 # Generated crds.yaml from github.com/longhorn/longhorn-manager/k8s/pkg/apis and the crds.yaml will be copied to longhorn/longhorn chart/templates and cannot be directly used by kubectl apply.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: backingimagedatasources.longhorn.io
 spec:
@@ -137,62 +18,6 @@ spec:
     singular: backingimagedatasource
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: The current state of the pod used to provision the backing image
-        file from source
-      jsonPath: .status.currentState
-      name: State
-      type: string
-    - description: The data source type
-      jsonPath: .spec.sourceType
-      name: SourceType
-      type: string
-    - description: The node the backing image file will be prepared on
-      jsonPath: .spec.nodeID
-      name: Node
-      type: string
-    - description: The disk the backing image file will be prepared on
-      jsonPath: .spec.diskUUID
-      name: DiskUUID
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    deprecated: true
-    deprecationWarning: longhorn.io/v1beta1 BackingImageDataSource is deprecated;
-      use longhorn.io/v1beta2 BackingImageDataSource instead
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: BackingImageDataSource is where Longhorn stores backing image
-          data source object.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: false
-    storage: false
-    subresources:
-      status: {}
   - additionalPrinterColumns:
     - description: The system generated UUID of the provisioned backing image file
       jsonPath: .spec.uuid
@@ -307,16 +132,12 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: backingimagemanagers.longhorn.io
 spec:
@@ -330,65 +151,6 @@ spec:
     singular: backingimagemanager
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: The current state of the manager
-      jsonPath: .status.currentState
-      name: State
-      type: string
-    - description: The image the manager pod will use
-      jsonPath: .spec.image
-      name: Image
-      type: string
-    - description: The node the manager is on
-      jsonPath: .spec.nodeID
-      name: Node
-      type: string
-    - description: The disk the manager is responsible for
-      jsonPath: .spec.diskUUID
-      name: DiskUUID
-      type: string
-    - description: The disk path the manager is using
-      jsonPath: .spec.diskPath
-      name: DiskPath
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    deprecated: true
-    deprecationWarning: longhorn.io/v1beta1 BackingImageManager is deprecated; use
-      longhorn.io/v1beta2 BackingImageManager instead
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: BackingImageManager is where Longhorn stores backing image manager
-          object.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: false
-    storage: false
-    subresources:
-      status: {}
   - additionalPrinterColumns:
     - description: The current state of the manager
       jsonPath: .status.currentState
@@ -507,31 +269,15 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: backingimages.longhorn.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: longhorn-conversion-webhook
-          namespace: longhorn-system
-          path: /v1/webhook/conversion
-          port: 9501
-      conversionReviewVersions:
-      - v1beta2
-      - v1beta1
   group: longhorn.io
   names:
     kind: BackingImage
@@ -542,48 +288,6 @@ spec:
     singular: backingimage
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: The backing image name
-      jsonPath: .spec.image
-      name: Image
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    deprecated: true
-    deprecationWarning: longhorn.io/v1beta1 BackingImage is deprecated; use longhorn.io/v1beta2
-      BackingImage instead
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: BackingImage is where Longhorn stores backing image object.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: false
-    storage: false
-    subresources:
-      status: {}
   - additionalPrinterColumns:
     - description: The system generated UUID
       jsonPath: .status.uuid
@@ -744,16 +448,12 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: backupbackingimages.longhorn.io
 spec:
@@ -915,16 +615,12 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: backups.longhorn.io
 spec:
@@ -938,61 +634,6 @@ spec:
     singular: backup
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: The snapshot name
-      jsonPath: .status.snapshotName
-      name: SnapshotName
-      type: string
-    - description: The snapshot size
-      jsonPath: .status.size
-      name: SnapshotSize
-      type: string
-    - description: The snapshot creation time
-      jsonPath: .status.snapshotCreatedAt
-      name: SnapshotCreatedAt
-      type: string
-    - description: The backup state
-      jsonPath: .status.state
-      name: State
-      type: string
-    - description: The backup last synced time
-      jsonPath: .status.lastSyncedAt
-      name: LastSyncedAt
-      type: string
-    deprecated: true
-    deprecationWarning: longhorn.io/v1beta1 Backup is deprecated; use longhorn.io/v1beta2
-      Backup instead
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: Backup is where Longhorn stores backup object.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: false
-    storage: false
-    subresources:
-      status: {}
   - additionalPrinterColumns:
     - description: The snapshot name
       jsonPath: .status.snapshotName
@@ -1043,6 +684,15 @@ spec:
           spec:
             description: BackupSpec defines the desired state of the Longhorn backup
             properties:
+              backupBlockSize:
+                description: The backup block size. 0 means the legacy default size
+                  2MiB, and -1 indicate the block size is invalid.
+                enum:
+                - "-1"
+                - "2097152"
+                - "16777216"
+                format: int64
+                type: string
               backupMode:
                 description: |-
                   The backup mode of this backup.
@@ -1050,7 +700,6 @@ spec:
                 enum:
                 - full
                 - incremental
-                - ""
                 type: string
               labels:
                 additionalProperties:
@@ -1152,31 +801,15 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: backuptargets.longhorn.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: longhorn-conversion-webhook
-          namespace: longhorn-system
-          path: /v1/webhook/conversion
-          port: 9501
-      conversionReviewVersions:
-      - v1beta2
-      - v1beta1
   group: longhorn.io
   names:
     kind: BackupTarget
@@ -1187,61 +820,6 @@ spec:
     singular: backuptarget
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: The backup target URL
-      jsonPath: .spec.backupTargetURL
-      name: URL
-      type: string
-    - description: The backup target credential secret
-      jsonPath: .spec.credentialSecret
-      name: Credential
-      type: string
-    - description: The backup target poll interval
-      jsonPath: .spec.pollInterval
-      name: LastBackupAt
-      type: string
-    - description: Indicate whether the backup target is available or not
-      jsonPath: .status.available
-      name: Available
-      type: boolean
-    - description: The backup target last synced time
-      jsonPath: .status.lastSyncedAt
-      name: LastSyncedAt
-      type: string
-    deprecated: true
-    deprecationWarning: longhorn.io/v1beta1 BackupTarget is deprecated; use longhorn.io/v1beta2
-      BackupTarget instead
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: BackupTarget is where Longhorn stores backup target object.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: false
-    storage: false
-    subresources:
-      status: {}
   - additionalPrinterColumns:
     - description: The backup target URL
       jsonPath: .spec.backupTargetURL
@@ -1360,16 +938,12 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: backupvolumes.longhorn.io
 spec:
@@ -1383,57 +957,6 @@ spec:
     singular: backupvolume
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: The backup volume creation time
-      jsonPath: .status.createdAt
-      name: CreatedAt
-      type: string
-    - description: The backup volume last backup name
-      jsonPath: .status.lastBackupName
-      name: LastBackupName
-      type: string
-    - description: The backup volume last backup time
-      jsonPath: .status.lastBackupAt
-      name: LastBackupAt
-      type: string
-    - description: The backup volume last synced time
-      jsonPath: .status.lastSyncedAt
-      name: LastSyncedAt
-      type: string
-    deprecated: true
-    deprecationWarning: longhorn.io/v1beta1 BackupVolume is deprecated; use longhorn.io/v1beta2
-      BackupVolume instead
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: BackupVolume is where Longhorn stores backup volume object.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: false
-    storage: false
-    subresources:
-      status: {}
   - additionalPrinterColumns:
     - description: The backup target name
       jsonPath: .spec.backupTargetName
@@ -1557,31 +1080,15 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: engineimages.longhorn.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: longhorn-conversion-webhook
-          namespace: longhorn-system
-          path: /v1/webhook/conversion
-          port: 9501
-      conversionReviewVersions:
-      - v1beta2
-      - v1beta1
   group: longhorn.io
   names:
     kind: EngineImage
@@ -1590,63 +1097,8 @@ spec:
     shortNames:
     - lhei
     singular: engineimage
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: State of the engine image
-      jsonPath: .status.state
-      name: State
-      type: string
-    - description: The Longhorn engine image
-      jsonPath: .spec.image
-      name: Image
-      type: string
-    - description: Number of resources using the engine image
-      jsonPath: .status.refCount
-      name: RefCount
-      type: integer
-    - description: The build date of the engine image
-      jsonPath: .status.buildDate
-      name: BuildDate
-      type: date
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    deprecated: true
-    deprecationWarning: longhorn.io/v1beta1 EngineImage is deprecated; use longhorn.io/v1beta2
-      EngineImage instead
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: EngineImage is where Longhorn stores engine image object.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: false
-    storage: false
-    subresources:
-      status: {}
   - additionalPrinterColumns:
     - description: Compatibility of the engine image
       jsonPath: .status.incompatible
@@ -1776,16 +1228,12 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: engines.longhorn.io
 spec:
@@ -1797,63 +1245,8 @@ spec:
     shortNames:
     - lhe
     singular: engine
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: The current state of the engine
-      jsonPath: .status.currentState
-      name: State
-      type: string
-    - description: The node that the engine is on
-      jsonPath: .spec.nodeID
-      name: Node
-      type: string
-    - description: The instance manager of the engine
-      jsonPath: .status.instanceManagerName
-      name: InstanceManager
-      type: string
-    - description: The current image of the engine
-      jsonPath: .status.currentImage
-      name: Image
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    deprecated: true
-    deprecationWarning: longhorn.io/v1beta1 Engine is deprecated; use longhorn.io/v1beta2
-      Engine instead
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: Engine is where Longhorn stores engine object.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: false
-    storage: false
-    subresources:
-      status: {}
   - additionalPrinterColumns:
     - description: The data engine of the engine
       jsonPath: .spec.dataEngine
@@ -1930,6 +1323,14 @@ spec:
                 type: boolean
               nodeID:
                 type: string
+              rebuildConcurrentSyncLimit:
+                description: |-
+                  RebuildConcurrentSyncLimit controls the maximum number of file synchronization operations that can run
+                  concurrently during a single replica rebuild.
+                  It is determined by the global setting or the volume spec field with the same name.
+                maximum: 5
+                minimum: 0
+                type: integer
               replicaAddressMap:
                 additionalProperties:
                   type: string
@@ -1947,6 +1348,14 @@ spec:
               snapshotMaxSize:
                 format: int64
                 type: string
+              ublkNumberOfQueue:
+                description: ublkNumberOfQueue controls the number of queues for ublk
+                  frontend.
+                type: integer
+              ublkQueueDepth:
+                description: ublkQueueDepth controls the depth of each queue for ublk
+                  frontend.
+                type: integer
               unmapMarkSnapChainRemovedEnabled:
                 type: boolean
               upgradedReplicaAddressMap:
@@ -2073,13 +1482,29 @@ spec:
                   type: object
                 nullable: true
                 type: object
+              rebuildConcurrentSyncLimit:
+                description: |-
+                  RebuildConcurrentSyncLimit controls the maximum number of file synchronization operations that can run
+                  concurrently during a single replica rebuild.
+                  It is determined by the global setting or the volume spec field with the same name.
+                minimum: 0
+                type: integer
               rebuildStatus:
                 additionalProperties:
                   properties:
+                    appliedRebuildingMBps:
+                      format: int64
+                      type: integer
                     error:
                       type: string
                     fromReplicaAddress:
+                      description: Deprecated. We are now using FromReplicaAddressList
+                        to list all source replicas.
                       type: string
+                    fromReplicaAddressList:
+                      items:
+                        type: string
+                      type: array
                     isRebuilding:
                       type: boolean
                     progress:
@@ -2163,6 +1588,8 @@ spec:
                 type: string
               started:
                 type: boolean
+              starting:
+                type: boolean
               storageIP:
                 type: string
               ublkID:
@@ -2179,16 +1606,12 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: instancemanagers.longhorn.io
 spec:
@@ -2200,59 +1623,8 @@ spec:
     shortNames:
     - lhim
     singular: instancemanager
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: The state of the instance manager
-      jsonPath: .status.currentState
-      name: State
-      type: string
-    - description: The type of the instance manager (engine or replica)
-      jsonPath: .spec.type
-      name: Type
-      type: string
-    - description: The node that the instance manager is running on
-      jsonPath: .spec.nodeID
-      name: Node
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    deprecated: true
-    deprecationWarning: longhorn.io/v1beta1 InstanceManager is deprecated; use longhorn.io/v1beta2
-      InstanceManager instead
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: InstanceManager is where Longhorn stores instance manager object.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: false
-    storage: false
-    subresources:
-      status: {}
   - additionalPrinterColumns:
     - description: The data engine of the instance manager
       jsonPath: .spec.dataEngine
@@ -2351,6 +1723,35 @@ spec:
                   type: object
                 nullable: true
                 type: object
+              conditions:
+                items:
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: |-
+                        Status is the status of the condition.
+                        Can be True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  type: object
+                nullable: true
+                type: array
               currentState:
                 type: string
               dataEngineStatus:
@@ -2358,6 +1759,16 @@ spec:
                   v2:
                     properties:
                       cpuMask:
+                        type: string
+                      interruptModeEnabled:
+                        description: |-
+                          InterruptModeEnabled indicates whether the V2 data engine is running in
+                          interrupt mode (true) or polling mode (false). Set by Longhorn manager;
+                          read-only to users.
+                        enum:
+                        - ""
+                        - "true"
+                        - "false"
                         type: string
                     type: object
                 type: object
@@ -2463,58 +1874,6 @@ spec:
                   type: object
                 nullable: true
                 type: object
-              instances:
-                additionalProperties:
-                  properties:
-                    spec:
-                      properties:
-                        dataEngine:
-                          type: string
-                        name:
-                          type: string
-                      type: object
-                    status:
-                      properties:
-                        conditions:
-                          additionalProperties:
-                            type: boolean
-                          nullable: true
-                          type: object
-                        endpoint:
-                          type: string
-                        errorMsg:
-                          type: string
-                        listen:
-                          type: string
-                        portEnd:
-                          format: int32
-                          type: integer
-                        portStart:
-                          format: int32
-                          type: integer
-                        resourceVersion:
-                          format: int64
-                          type: integer
-                        state:
-                          type: string
-                        targetPortEnd:
-                          format: int32
-                          type: integer
-                        targetPortStart:
-                          format: int32
-                          type: integer
-                        type:
-                          type: string
-                        ublkID:
-                          format: int32
-                          type: integer
-                        uuid:
-                          type: string
-                      type: object
-                  type: object
-                description: 'Deprecated: Replaced by InstanceEngines and InstanceReplicas'
-                nullable: true
-                type: object
               ip:
                 type: string
               ownerID:
@@ -2530,31 +1889,15 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: nodes.longhorn.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: longhorn-conversion-webhook
-          namespace: longhorn-system
-          path: /v1/webhook/conversion
-          port: 9501
-      conversionReviewVersions:
-      - v1beta2
-      - v1beta1
   group: longhorn.io
   names:
     kind: Node
@@ -2563,60 +1906,8 @@ spec:
     shortNames:
     - lhn
     singular: node
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Indicate whether the node is ready
-      jsonPath: .status.conditions['Ready']['status']
-      name: Ready
-      type: string
-    - description: Indicate whether the user disabled/enabled replica scheduling for
-        the node
-      jsonPath: .spec.allowScheduling
-      name: AllowScheduling
-      type: boolean
-    - description: Indicate whether Longhorn can schedule replicas on the node
-      jsonPath: .status.conditions['Schedulable']['status']
-      name: Schedulable
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    deprecated: true
-    deprecationWarning: longhorn.io/v1beta1 Node is deprecated; use longhorn.io/v1beta2
-      Node instead
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: Node is where Longhorn stores Longhorn node object.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: false
-    storage: false
-    subresources:
-      status: {}
   - additionalPrinterColumns:
     - description: Indicate whether the node is ready
       jsonPath: .status.conditions[?(@.type=='Ready')].status
@@ -2671,6 +1962,7 @@ spec:
                       - ""
                       - auto
                       - aio
+                      - nvme
                       type: string
                     diskType:
                       enum:
@@ -2779,6 +2071,63 @@ spec:
                       type: string
                     filesystemType:
                       type: string
+                    healthData:
+                      additionalProperties:
+                        properties:
+                          attributes:
+                            items:
+                              properties:
+                                id:
+                                  type: integer
+                                name:
+                                  type: string
+                                rawString:
+                                  type: string
+                                rawValue:
+                                  format: int64
+                                  type: integer
+                                threshold:
+                                  type: integer
+                                value:
+                                  type: integer
+                                whenFailed:
+                                  type: string
+                                worst:
+                                  type: integer
+                              type: object
+                            type: array
+                          capacity:
+                            format: int64
+                            type: integer
+                          diskName:
+                            type: string
+                          diskType:
+                            type: string
+                          firmwareVersion:
+                            type: string
+                          healthStatus:
+                            enum:
+                            - FAILED
+                            - PASSED
+                            - UNKNOWN
+                            - WARNING
+                            type: string
+                          modelName:
+                            type: string
+                          serialNumber:
+                            type: string
+                          source:
+                            enum:
+                            - SMART
+                            - SPDK
+                            type: string
+                          temperature:
+                            type: integer
+                        type: object
+                      type: object
+                    healthDataLastCollectedAt:
+                      format: date-time
+                      type: string
                     instanceManagerName:
                       type: string
                     scheduledBackingImage:
@@ -2822,16 +2171,12 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: orphans.longhorn.io
 spec:
@@ -2945,16 +2290,12 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: recurringjobs.longhorn.io
 spec:
@@ -2968,69 +2309,6 @@ spec:
     singular: recurringjob
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Sets groupings to the jobs. When set to "default" group will be
-        added to the volume label when no other job label exist in volume
-      jsonPath: .spec.groups
-      name: Groups
-      type: string
-    - description: Should be one of "backup" or "snapshot"
-      jsonPath: .spec.task
-      name: Task
-      type: string
-    - description: The cron expression represents recurring job scheduling
-      jsonPath: .spec.cron
-      name: Cron
-      type: string
-    - description: The number of snapshots/backups to keep for the volume
-      jsonPath: .spec.retain
-      name: Retain
-      type: integer
-    - description: The concurrent job to run by each cron job
-      jsonPath: .spec.concurrency
-      name: Concurrency
-      type: integer
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - description: Specify the labels
-      jsonPath: .spec.labels
-      name: Labels
-      type: string
-    deprecated: true
-    deprecationWarning: longhorn.io/v1beta1 RecurringJob is deprecated; use longhorn.io/v1beta2
-      RecurringJob instead
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: RecurringJob is where Longhorn stores recurring job object.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: false
-    storage: false
-    subresources:
-      status: {}
   - additionalPrinterColumns:
     - description: Sets groupings to the jobs. When set to "default" group will be
         added to the volume label when no other job label exist in volume
@@ -3149,16 +2427,12 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: replicas.longhorn.io
 spec:
@@ -3170,67 +2444,8 @@ spec:
     shortNames:
     - lhr
     singular: replica
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: The current state of the replica
-      jsonPath: .status.currentState
-      name: State
-      type: string
-    - description: The node that the replica is on
-      jsonPath: .spec.nodeID
-      name: Node
-      type: string
-    - description: The disk that the replica is on
-      jsonPath: .spec.diskID
-      name: Disk
-      type: string
-    - description: The instance manager of the replica
-      jsonPath: .status.instanceManagerName
-      name: InstanceManager
-      type: string
-    - description: The current image of the replica
-      jsonPath: .status.currentImage
-      name: Image
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    deprecated: true
-    deprecationWarning: longhorn.io/v1beta1 Replica is deprecated; use longhorn.io/v1beta2
-      Replica instead
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: Replica is where Longhorn stores replica object.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: false
-    storage: false
-    subresources:
-      status: {}
   - additionalPrinterColumns:
     - description: The data engine of the replica
       jsonPath: .spec.dataEngine
@@ -3409,9 +2624,6 @@ spec:
                 type: string
               currentState:
                 type: string
-              evictionRequested:
-                description: 'Deprecated: Replaced by field `spec.evictionRequested`.'
-                type: boolean
               instanceManagerName:
                 type: string
               ip:
@@ -3425,6 +2637,8 @@ spec:
               salvageExecuted:
                 type: boolean
               started:
+                type: boolean
+              starting:
                 type: boolean
               storageIP:
                 type: string
@@ -3440,16 +2654,12 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: settings.longhorn.io
 spec:
@@ -3461,51 +2671,8 @@ spec:
     shortNames:
     - lhs
     singular: setting
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: The value of the setting
-      jsonPath: .value
-      name: Value
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    deprecated: true
-    deprecationWarning: longhorn.io/v1beta1 Setting is deprecated; use longhorn.io/v1beta2
-      Setting instead
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: Setting is where Longhorn stores setting object.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          value:
-            type: string
-        required:
-        - value
-        type: object
-    served: false
-    storage: false
-    subresources:
-      status: {}
   - additionalPrinterColumns:
     - description: The value of the setting
       jsonPath: .value
@@ -3550,7 +2717,10 @@ spec:
             - applied
             type: object
           value:
-            description: The value of the setting.
+            description: |-
+              The value of the setting.
+              - It can be a non-JSON formatted string that is applied to all the applicable data engines listed in the setting definition.
+              - It can be a JSON formatted string that contains values for applicable data engines listed in the setting definition's Default.
             type: string
         required:
         - value
@@ -3560,16 +2730,12 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: sharemanagers.longhorn.io
 spec:
@@ -3583,52 +2749,6 @@ spec:
     singular: sharemanager
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: The state of the share manager
-      jsonPath: .status.state
-      name: State
-      type: string
-    - description: The node that the share manager is owned by
-      jsonPath: .status.ownerID
-      name: Node
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    deprecated: true
-    deprecationWarning: longhorn.io/v1beta1 ShareManager is deprecated; use longhorn.io/v1beta2
-      ShareManager instead
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ShareManager is where Longhorn stores share manager object.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: false
-    storage: false
-    subresources:
-      status: {}
   - additionalPrinterColumns:
     - description: The state of the share manager
       jsonPath: .status.state
@@ -3694,16 +2814,12 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: snapshots.longhorn.io
 spec:
@@ -3827,16 +2943,12 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: supportbundles.longhorn.io
 spec:
@@ -3962,16 +3074,12 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: systembackups.longhorn.io
 spec:
@@ -4103,16 +3211,12 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: systemrestores.longhorn.io
 spec:
@@ -4216,16 +3320,12 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: volumeattachments.longhorn.io
 spec:
@@ -4364,31 +3464,15 @@ spec:
     subresources:
       status: {}
 ---
-# Source: longhorn/templates/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
     longhorn-manager: ""
   name: volumes.longhorn.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: longhorn-conversion-webhook
-          namespace: longhorn-system
-          path: /v1/webhook/conversion
-          port: 9501
-      conversionReviewVersions:
-      - v1beta2
-      - v1beta1
   group: longhorn.io
   names:
     kind: Volume
@@ -4397,67 +3481,8 @@ spec:
     shortNames:
     - lhv
     singular: volume
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: The state of the volume
-      jsonPath: .status.state
-      name: State
-      type: string
-    - description: The robustness of the volume
-      jsonPath: .status.robustness
-      name: Robustness
-      type: string
-    - description: The scheduled condition of the volume
-      jsonPath: .status.conditions['scheduled']['status']
-      name: Scheduled
-      type: string
-    - description: The size of the volume
-      jsonPath: .spec.size
-      name: Size
-      type: string
-    - description: The node that the volume is currently attaching to
-      jsonPath: .status.currentNodeID
-      name: Node
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    deprecated: true
-    deprecationWarning: longhorn.io/v1beta1 Volume is deprecated; use longhorn.io/v1beta2
-      Volume instead
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: Volume is where Longhorn stores volume object.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: false
-    storage: false
-    subresources:
-      status: {}
   - additionalPrinterColumns:
     - description: The data engine of the volume
       jsonPath: .spec.dataEngine
@@ -4516,9 +3541,21 @@ spec:
               accessMode:
                 enum:
                 - rwo
+                - rwop
                 - rwx
                 type: string
               backingImage:
+                type: string
+                x-kubernetes-validations:
+                - message: BackingImage is immutable
+                  rule: self == oldSelf
+              backupBlockSize:
+                description: BackupBlockSize indicate the block size to create backups.
+                  The block size is immutable.
+                enum:
+                - "2097152"
+                - "16777216"
+                format: int64
                 type: string
               backupCompressionMethod:
                 enum:
@@ -4529,6 +3566,12 @@ spec:
               backupTargetName:
                 description: The backup target name that the volume will be backed
                   up to or is synced.
+                type: string
+              cloneMode:
+                enum:
+                - ""
+                - full-copy
+                - linked-clone
                 type: string
               dataEngine:
                 enum:
@@ -4551,6 +3594,9 @@ spec:
                 type: array
               encrypted:
                 type: boolean
+                x-kubernetes-validations:
+                - message: Encrypted is immutable
+                  rule: self == oldSelf
               freezeFilesystemForSnapshot:
                 description: Setting that freezes the filesystem on the root partition
                   before a snapshot is created.
@@ -4596,6 +3642,14 @@ spec:
                 - disabled
                 - enabled
                 type: string
+              rebuildConcurrentSyncLimit:
+                description: |-
+                  RebuildConcurrentSyncLimit controls the maximum number of file synchronization operations that can run
+                  concurrently during a single replica rebuild.
+                  When set to 0, it means following the global setting.
+                maximum: 5
+                minimum: 0
+                type: integer
               replicaAutoBalance:
                 enum:
                 - ignored
@@ -4611,6 +3665,14 @@ spec:
                 - enabled
                 - disabled
                 type: string
+              replicaRebuildingBandwidthLimit:
+                description: ReplicaRebuildingBandwidthLimit controls the maximum
+                  write bandwidth (in megabytes per second) allowed on the destination
+                  replica during the rebuilding process. Set this value to 0 to disable
+                  bandwidth limiting.
+                format: int64
+                minimum: 0
+                type: integer
               replicaSoftAntiAffinity:
                 description: Replica soft anti affinity of the volume. Set enabled
                   to allow replicas to be scheduled on the same node.
@@ -4651,6 +3713,14 @@ spec:
                 format: int64
                 type: string
               staleReplicaTimeout:
+                type: integer
+              ublkNumberOfQueue:
+                description: ublkNumberOfQueue controls the number of queues for ublk
+                  frontend.
+                type: integer
+              ublkQueueDepth:
+                description: ublkQueueDepth controls the depth of each queue for ublk
+                  frontend.
                 type: integer
               unmapMarkSnapChainRemoved:
                 enum:
@@ -4779,475 +3849,3 @@ spec:
     storage: true
     subresources:
       status: {}
----
-# Source: longhorn/templates/clusterrole.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: longhorn-role
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
-rules:
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - "*"
-- apiGroups: [""]
-  resources: ["pods", "events", "persistentvolumes", "persistentvolumeclaims", "persistentvolumeclaims/status", "nodes", "proxy/nodes", "pods/log", "secrets", "services", "endpoints", "configmaps", "serviceaccounts"]
-  verbs: ["*"]
-- apiGroups: [""]
-  resources: ["namespaces"]
-  verbs: ["get", "list"]
-- apiGroups: ["apps"]
-  resources: ["daemonsets", "statefulsets", "deployments"]
-  verbs: ["*"]
-- apiGroups: ["batch"]
-  resources: ["jobs", "cronjobs"]
-  verbs: ["*"]
-- apiGroups: ["policy"]
-  resources: ["poddisruptionbudgets", "podsecuritypolicies"]
-  verbs: ["*"]
-- apiGroups: ["scheduling.k8s.io"]
-  resources: ["priorityclasses"]
-  verbs: ["watch", "list"]
-- apiGroups: ["storage.k8s.io"]
-  resources: ["storageclasses", "volumeattachments", "volumeattachments/status", "csinodes", "csidrivers"]
-  verbs: ["*"]
-- apiGroups: ["snapshot.storage.k8s.io"]
-  resources: ["volumesnapshotclasses", "volumesnapshots", "volumesnapshotcontents", "volumesnapshotcontents/status"]
-  verbs: ["*"]
-- apiGroups: ["longhorn.io"]
-  resources: ["volumes", "volumes/status", "engines", "engines/status", "replicas", "replicas/status", "settings", "settings/status",
-              "engineimages", "engineimages/status", "nodes", "nodes/status", "instancemanagers", "instancemanagers/status",
-              "sharemanagers", "sharemanagers/status", "backingimages", "backingimages/status",
-              "backingimagemanagers", "backingimagemanagers/status", "backingimagedatasources", "backingimagedatasources/status",
-              "backuptargets", "backuptargets/status", "backupvolumes", "backupvolumes/status", "backups", "backups/status",
-              "recurringjobs", "recurringjobs/status", "orphans", "orphans/status", "snapshots", "snapshots/status",
-              "supportbundles", "supportbundles/status", "systembackups", "systembackups/status", "systemrestores", "systemrestores/status",
-              "volumeattachments", "volumeattachments/status", "backupbackingimages", "backupbackingimages/status"]
-  verbs: ["*"]
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["*"]
-- apiGroups: ["metrics.k8s.io"]
-  resources: ["pods", "nodes"]
-  verbs: ["get", "list"]
-- apiGroups: ["apiregistration.k8s.io"]
-  resources: ["apiservices"]
-  verbs: ["list", "watch"]
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
-  verbs: ["get", "list", "create", "patch", "delete"]
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["roles", "rolebindings", "clusterrolebindings", "clusterroles"]
-  verbs: ["*"]
----
-# Source: longhorn/templates/clusterrolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: longhorn-bind
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: longhorn-role
-subjects:
-- kind: ServiceAccount
-  name: longhorn-service-account
-  namespace: longhorn-system
----
-# Source: longhorn/templates/clusterrolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: longhorn-support-bundle
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-- kind: ServiceAccount
-  name: longhorn-support-bundle
-  namespace: longhorn-system
----
-# Source: longhorn/templates/daemonset-sa.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
-    app: longhorn-manager
-  name: longhorn-backend
-  namespace: longhorn-system
-spec:
-  type: ClusterIP
-  selector:
-    app: longhorn-manager
-  ports:
-  - name: manager
-    port: 9500
-    targetPort: manager
----
-# Source: longhorn/templates/deployment-ui.yaml
-kind: Service
-apiVersion: v1
-metadata:
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
-    app: longhorn-ui
-  annotations:
-    external-dns.alpha.kubernetes.io/hostname: longhorn.homelab.local
-  name: longhorn-frontend
-  namespace: longhorn-system
-spec:
-  type: LoadBalancer
-  loadBalancerIP: 192.168.0.241
-  selector:
-    app: longhorn-ui
-  ports:
-  - name: http
-    port: 80
-    targetPort: http
-    nodePort: null
----
-# Source: longhorn/templates/services.yaml
-#
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
-    app: longhorn-conversion-webhook
-  name: longhorn-conversion-webhook
-  namespace: longhorn-system
-spec:
-  type: ClusterIP
-  selector:
-    longhorn.io/conversion-webhook: longhorn-conversion-webhook
-  ports:
-  - name: conversion-webhook
-    port: 9501
-    targetPort: conversion-wh
----
-# Source: longhorn/templates/services.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
-    app: longhorn-admission-webhook
-  name: longhorn-admission-webhook
-  namespace: longhorn-system
-spec:
-  type: ClusterIP
-  selector:
-    longhorn.io/admission-webhook: longhorn-admission-webhook
-  ports:
-  - name: admission-webhook
-    port: 9502
-    targetPort: admission-wh
----
-# Source: longhorn/templates/services.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
-    app: longhorn-recovery-backend
-  name: longhorn-recovery-backend
-  namespace: longhorn-system
-spec:
-  type: ClusterIP
-  selector:
-    longhorn.io/recovery-backend: longhorn-recovery-backend
-  ports:
-  - name: recovery-backend
-    port: 9503
-    targetPort: recov-backend
----
-# Source: longhorn/templates/daemonset-sa.yaml
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  annotations:
-    ignore-check.kube-linter.io/privileged-container: "Longhorn needs access to storage"
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
-    app: longhorn-manager
-  name: longhorn-manager
-  namespace: longhorn-system
-spec:
-  selector:
-    matchLabels:
-      app: longhorn-manager
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: longhorn
-        app.kubernetes.io/instance: longhorn
-        app.kubernetes.io/version: v1.9.0
-        app: longhorn-manager
-    spec:
-      containers:
-      - name: longhorn-manager
-        image: longhornio/longhorn-manager:v1.9.0
-        imagePullPolicy: IfNotPresent
-        securityContext:
-          privileged: true
-        command:
-        - longhorn-manager
-        - -d
-        - daemon
-        - --engine-image
-        - "longhornio/longhorn-engine:v1.9.0"
-        - --instance-manager-image
-        - "longhornio/longhorn-instance-manager:v1.9.0"
-        - --share-manager-image
-        - "longhornio/longhorn-share-manager:v1.9.0"
-        - --backing-image-manager-image
-        - "longhornio/backing-image-manager:v1.9.0"
-        - --support-bundle-manager-image
-        - "longhornio/support-bundle-kit:v0.0.55"
-        - --manager-image
-        - "longhornio/longhorn-manager:v1.9.0"
-        - --service-account
-        - longhorn-service-account
-        - --upgrade-version-check
-        ports:
-        - containerPort: 9500
-          name: manager
-        - containerPort: 9501
-          name: conversion-wh
-        - containerPort: 9502
-          name: admission-wh
-        - containerPort: 9503
-          name: recov-backend
-        readinessProbe:
-          httpGet:
-            path: /v1/healthz
-            port: 9501
-            scheme: HTTPS
-        volumeMounts:
-        - name: boot
-          mountPath: /host/boot/
-          readOnly: true
-        - name: dev
-          mountPath: /host/dev/
-        - name: proc
-          mountPath: /host/proc/
-          readOnly: true
-        - name: etc
-          mountPath: /host/etc/
-          readOnly: true
-        - name: longhorn
-          mountPath: /var/lib/longhorn/
-          mountPropagation: Bidirectional
-        - name: longhorn-grpc-tls
-          mountPath: /tls-files/
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-      - name: pre-pull-share-manager-image
-        imagePullPolicy: IfNotPresent
-        image: longhornio/longhorn-share-manager:v1.9.0
-        command: ["sh", "-c", "echo share-manager image pulled && sleep infinity"]
-      volumes:
-      - name: boot
-        hostPath:
-          path: /boot/
-      - name: dev
-        hostPath:
-          path: /dev/
-      - name: proc
-        hostPath:
-          path: /proc/
-      - name: etc
-        hostPath:
-          path: /etc/
-      - name: longhorn
-        hostPath:
-          path: /var/lib/longhorn/
-      - name: longhorn-grpc-tls
-        secret:
-          secretName: longhorn-grpc-tls
-          optional: true
-      priorityClassName: "longhorn-critical"
-      serviceAccountName: longhorn-service-account
-  updateStrategy:
-    rollingUpdate:
-      maxUnavailable: "100%"
----
-# Source: longhorn/templates/deployment-driver.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: longhorn-driver-deployer
-  namespace: longhorn-system
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: longhorn-driver-deployer
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: longhorn
-        app.kubernetes.io/instance: longhorn
-        app.kubernetes.io/version: v1.9.0
-        app: longhorn-driver-deployer
-    spec:
-      initContainers:
-        - name: wait-longhorn-manager
-          image: longhornio/longhorn-manager:v1.9.0
-          command: ['sh', '-c', 'while [ $(curl -m 1 -s -o /dev/null -w "%{http_code}" http://longhorn-backend:9500/v1) != "200" ]; do echo waiting; sleep 2; done']
-      containers:
-        - name: longhorn-driver-deployer
-          image: longhornio/longhorn-manager:v1.9.0
-          imagePullPolicy: IfNotPresent
-          command:
-          - longhorn-manager
-          - -d
-          - deploy-driver
-          - --manager-image
-          - "longhornio/longhorn-manager:v1.9.0"
-          - --manager-url
-          - http://longhorn-backend:9500/v1
-          env:
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: SERVICE_ACCOUNT
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.serviceAccountName
-          - name: CSI_ATTACHER_IMAGE
-            value: "longhornio/csi-attacher:v4.8.1"
-          - name: CSI_PROVISIONER_IMAGE
-            value: "longhornio/csi-provisioner:v5.2.0"
-          - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
-            value: "longhornio/csi-node-driver-registrar:v2.13.0"
-          - name: CSI_RESIZER_IMAGE
-            value: "longhornio/csi-resizer:v1.13.2"
-          - name: CSI_SNAPSHOTTER_IMAGE
-            value: "longhornio/csi-snapshotter:v8.2.0"
-          - name: CSI_LIVENESS_PROBE_IMAGE
-            value: "longhornio/livenessprobe:v2.15.0"
-      priorityClassName: "longhorn-critical"
-      serviceAccountName: longhorn-service-account
-      securityContext:
-        runAsUser: 0
----
-# Source: longhorn/templates/deployment-ui.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.9.0
-    app: longhorn-ui
-  name: longhorn-ui
-  namespace: longhorn-system
-spec:
-  replicas: 2
-  selector:
-    matchLabels:
-      app: longhorn-ui
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: longhorn
-        app.kubernetes.io/instance: longhorn
-        app.kubernetes.io/version: v1.9.0
-        app: longhorn-ui
-    spec:
-      serviceAccountName: longhorn-ui-service-account
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - longhorn-ui
-              topologyKey: kubernetes.io/hostname
-            weight: 1
-      containers:
-      - name: longhorn-ui
-        image: longhornio/longhorn-ui:v1.9.0
-        imagePullPolicy: IfNotPresent
-        volumeMounts:
-        - name: nginx-cache
-          mountPath: /var/cache/nginx/
-        - name: nginx-config
-          mountPath: /var/config/nginx/
-        - name: var-run
-          mountPath: /var/run/
-        ports:
-        - containerPort: 8000
-          name: http
-        env:
-          - name: LONGHORN_MANAGER_IP
-            value: "http://longhorn-backend:9500"
-          - name: LONGHORN_UI_PORT
-            value: "8000"
-      volumes:
-      - emptyDir: {}
-        name: nginx-cache
-      - emptyDir: {}
-        name: nginx-config
-      - emptyDir: {}
-        name: var-run
-      priorityClassName: "longhorn-critical"
----
-# Source: longhorn/templates/validate-psp-install.yaml
-#

--- a/manifests/core/longhorn/templates/daemonset-sa.yaml
+++ b/manifests/core/longhorn/templates/daemonset-sa.yaml
@@ -1,0 +1,205 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-manager
+  name: longhorn-manager
+  namespace: {{ include "release_namespace" . }}
+spec:
+  selector:
+    matchLabels:
+      app: longhorn-manager
+  template:
+    metadata:
+      labels: {{- include "longhorn.labels" . | nindent 8 }}
+        app: longhorn-manager
+      {{- with .Values.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      containers:
+      - name: longhorn-manager
+        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          privileged: true
+        command:
+        - longhorn-manager
+        - -d
+        {{- if eq .Values.longhornManager.log.format "json" }}
+        - -j
+        {{- end }}
+        - daemon
+        - --engine-image
+        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.engine.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.engine.repository }}:{{ .Values.image.longhorn.engine.tag }}"
+        - --instance-manager-image
+        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.instanceManager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.instanceManager.repository }}:{{ .Values.image.longhorn.instanceManager.tag }}"
+        - --share-manager-image
+        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.shareManager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.shareManager.repository }}:{{ .Values.image.longhorn.shareManager.tag }}"
+        - --backing-image-manager-image
+        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.backingImageManager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.backingImageManager.repository }}:{{ .Values.image.longhorn.backingImageManager.tag }}"
+        - --support-bundle-manager-image
+        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.supportBundleKit.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.supportBundleKit.repository }}:{{ .Values.image.longhorn.supportBundleKit.tag }}"
+        - --manager-image
+        - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}"
+        - --service-account
+        - longhorn-service-account
+        {{- if .Values.preUpgradeChecker.upgradeVersionCheck}}
+        - --upgrade-version-check
+        {{- end }}
+        ports:
+        - containerPort: 9500
+          name: manager
+        - containerPort: 9502
+          name: admission-wh
+        - containerPort: 9503
+          name: recov-backend
+        readinessProbe:
+          httpGet:
+            path: /v1/healthz
+            port: 9502
+            scheme: HTTPS
+        volumeMounts:
+        - name: boot
+          mountPath: /host/boot/
+          readOnly: true
+        - name: dev
+          mountPath: /host/dev/
+        - name: proc
+          mountPath: /host/proc/
+          readOnly: true
+        - name: etc
+          mountPath: /host/etc/
+          readOnly: true
+        - name: longhorn
+          mountPath: /var/lib/longhorn/
+          mountPropagation: Bidirectional
+        - name: longhorn-grpc-tls
+          mountPath: /tls-files/
+        {{- if .Values.enableGoCoverDir }}
+        - name: go-cover-dir
+          mountPath: /go-cover-dir/
+        {{- end }}
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        {{- if .Values.enableGoCoverDir }}
+        - name: GOCOVERDIR
+          value: /go-cover-dir/
+        {{- end }}
+        {{- include "longhorn.timezoneEnv" . | nindent 8 }}
+        {{- with .Values.longhornManager.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      - name: pre-pull-share-manager-image
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.shareManager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.shareManager.repository }}:{{ .Values.image.longhorn.shareManager.tag }}
+        command: ["sh", "-c", "echo share-manager image pulled && sleep infinity"]
+      volumes:
+      - name: boot
+        hostPath:
+          path: /boot/
+      - name: dev
+        hostPath:
+          path: /dev/
+      - name: proc
+        hostPath:
+          path: /proc/
+      - name: etc
+        hostPath:
+          path: /etc/
+      - name: longhorn
+        hostPath:
+          path: /var/lib/longhorn/
+      {{- if .Values.enableGoCoverDir }}
+      - name: go-cover-dir
+        hostPath:
+          path: /go-cover-dir/
+          type: DirectoryOrCreate
+      {{- end }}
+      - name: longhorn-grpc-tls
+        secret:
+          secretName: longhorn-grpc-tls
+          optional: true
+      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
+      imagePullSecrets:
+        {{- $imagePullSecrets := list }}
+        {{- if kindIs "string" . }}
+          {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+        {{- else }}
+          {{- range . }}
+            {{- if kindIs "string" . }}
+                {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+            {{- else }}
+                {{- $imagePullSecrets = append $imagePullSecrets . }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- toYaml $imagePullSecrets | nindent 8 }}
+      {{- end }}
+      {{- if .Values.longhornManager.priorityClass }}
+      priorityClassName: {{ .Values.longhornManager.priorityClass | quote }}
+      {{- end }}
+      {{- if or .Values.global.tolerations .Values.longhornManager.tolerations .Values.global.cattle.windowsCluster.enabled }}
+      tolerations:
+        {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.tolerations }}
+{{ toYaml .Values.global.cattle.windowsCluster.tolerations | indent 6 }}
+        {{- end }}
+        {{- if or .Values.global.tolerations .Values.longhornManager.tolerations }}
+{{ default .Values.global.tolerations .Values.longhornManager.tolerations | toYaml | indent 6 }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.global.nodeSelector .Values.longhornManager.nodeSelector .Values.global.cattle.windowsCluster.enabled }}
+      nodeSelector:
+        {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.nodeSelector }}
+{{ toYaml .Values.global.cattle.windowsCluster.nodeSelector | indent 8 }}
+        {{- end }}
+        {{- if or .Values.global.nodeSelector .Values.longhornManager.nodeSelector }}
+{{ default .Values.global.nodeSelector .Values.longhornManager.nodeSelector | toYaml | indent 8 }}
+        {{- end }}
+      {{- end }}
+      serviceAccountName: longhorn-service-account
+  updateStrategy:
+{{ toYaml .Values.longhornManager.updateStrategy | indent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-manager
+    {{- with .Values.longhornManager.serviceLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: longhorn-backend
+  namespace: {{ include "release_namespace" . }}
+  {{- if .Values.longhornManager.serviceAnnotations }}
+  annotations:
+{{ toYaml .Values.longhornManager.serviceAnnotations | indent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.manager.type }}
+  selector:
+    app: longhorn-manager
+  ports:
+  - name: manager
+    port: 9500
+    targetPort: manager
+    {{- if .Values.service.manager.nodePort }}
+    nodePort: {{ .Values.service.manager.nodePort }}
+    {{- end }}

--- a/manifests/core/longhorn/templates/daemonset-sa.yaml
+++ b/manifests/core/longhorn/templates/daemonset-sa.yaml
@@ -5,6 +5,8 @@ metadata:
     app: longhorn-manager
   name: longhorn-manager
   namespace: {{ include "release_namespace" . }}
+  annotations:
+    ignore-check.kube-linter.io/privileged-container: "Needs privileged access for storage"
 spec:
   selector:
     matchLabels:
@@ -15,6 +17,7 @@ spec:
         app: longhorn-manager
       {{- with .Values.annotations }}
       annotations:
+        ignore-check.kube-linter.io/privileged-container: "Needs privileged access for storage"
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/manifests/core/longhorn/templates/default-resource.yaml
+++ b/manifests/core/longhorn/templates/default-resource.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: longhorn-default-resource
+  namespace: {{ include "release_namespace" . }}
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+data:
+  default-resource.yaml: |-
+    {{- if not (kindIs "invalid" .Values.defaultBackupStore.backupTarget) }}
+    backup-target: {{ .Values.defaultBackupStore.backupTarget }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultBackupStore.backupTargetCredentialSecret) }}
+    backup-target-credential-secret: {{ .Values.defaultBackupStore.backupTargetCredentialSecret }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultBackupStore.pollInterval) }}
+    backupstore-poll-interval: {{ .Values.defaultBackupStore.pollInterval }}
+    {{- end }}

--- a/manifests/core/longhorn/templates/default-setting.yaml
+++ b/manifests/core/longhorn/templates/default-setting.yaml
@@ -1,0 +1,292 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: longhorn-default-setting
+  namespace: {{ include "release_namespace" . }}
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+data:
+  default-setting.yaml: |-
+    {{- if not (kindIs "invalid" .Values.defaultSettings.allowRecurringJobWhileVolumeDetached) }}
+    allow-recurring-job-while-volume-detached: {{ .Values.defaultSettings.allowRecurringJobWhileVolumeDetached }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.createDefaultDiskLabeledNodes) }}
+    create-default-disk-labeled-nodes: {{ .Values.defaultSettings.createDefaultDiskLabeledNodes }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.defaultDataPath) }}
+    default-data-path: {{ .Values.defaultSettings.defaultDataPath | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.replicaSoftAntiAffinity) }}
+    replica-soft-anti-affinity: {{ .Values.defaultSettings.replicaSoftAntiAffinity }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.replicaAutoBalance) }}
+    replica-auto-balance: {{ .Values.defaultSettings.replicaAutoBalance | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.storageOverProvisioningPercentage) }}
+    storage-over-provisioning-percentage: {{ .Values.defaultSettings.storageOverProvisioningPercentage | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.storageMinimalAvailablePercentage) }}
+    storage-minimal-available-percentage: {{ .Values.defaultSettings.storageMinimalAvailablePercentage | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.storageReservedPercentageForDefaultDisk) }}
+    storage-reserved-percentage-for-default-disk: {{ .Values.defaultSettings.storageReservedPercentageForDefaultDisk | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.upgradeChecker) }}
+    upgrade-checker: {{ .Values.defaultSettings.upgradeChecker }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.upgradeResponderURL) }}
+    upgrade-responder-url: {{ .Values.defaultSettings.upgradeResponderURL | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.managerUrl) }}
+    manager-url: {{ .Values.defaultSettings.managerUrl | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.defaultReplicaCount) }}
+    default-replica-count: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.defaultReplicaCount }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.defaultDataLocality) }}
+    default-data-locality: {{ .Values.defaultSettings.defaultDataLocality | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.defaultLonghornStaticStorageClass) }}
+    default-longhorn-static-storage-class: {{ .Values.defaultSettings.defaultLonghornStaticStorageClass | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.failedBackupTTL) }}
+    failed-backup-ttl: {{ .Values.defaultSettings.failedBackupTTL | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.backupExecutionTimeout) }}
+    backup-execution-timeout: {{ .Values.defaultSettings.backupExecutionTimeout | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.restoreVolumeRecurringJobs) }}
+    restore-volume-recurring-jobs: {{ .Values.defaultSettings.restoreVolumeRecurringJobs }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.recurringSuccessfulJobsHistoryLimit) }}
+    recurring-successful-jobs-history-limit: {{ .Values.defaultSettings.recurringSuccessfulJobsHistoryLimit | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.recurringJobMaxRetention) }}
+    recurring-job-max-retention: {{ .Values.defaultSettings.recurringJobMaxRetention | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.recurringFailedJobsHistoryLimit) }}
+    recurring-failed-jobs-history-limit: {{ .Values.defaultSettings.recurringFailedJobsHistoryLimit | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.supportBundleFailedHistoryLimit) }}
+    support-bundle-failed-history-limit: {{ .Values.defaultSettings.supportBundleFailedHistoryLimit | quote }}
+    {{- end }}
+    {{- if or (not (kindIs "invalid" .Values.defaultSettings.taintToleration)) (.Values.global.cattle.windowsCluster.enabled) }}
+    taint-toleration: {{ $windowsDefaultSettingTaintToleration := list }}{{ $defaultSettingTaintToleration := list -}}
+      {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.defaultSetting.taintToleration -}}
+        {{- $windowsDefaultSettingTaintToleration = .Values.global.cattle.windowsCluster.defaultSetting.taintToleration -}}
+      {{- end -}}
+      {{- if not (kindIs "invalid" .Values.defaultSettings.taintToleration) -}}
+        {{- $defaultSettingTaintToleration = .Values.defaultSettings.taintToleration -}}
+      {{- end -}}
+      {{- $taintToleration := list $windowsDefaultSettingTaintToleration $defaultSettingTaintToleration }}{{ join ";" (compact $taintToleration) | quote -}}
+    {{- end }}
+    {{- if or (not (kindIs "invalid" .Values.defaultSettings.systemManagedComponentsNodeSelector)) (.Values.global.cattle.windowsCluster.enabled) }}
+    system-managed-components-node-selector: {{ $windowsDefaultSettingNodeSelector := list }}{{ $defaultSettingNodeSelector := list -}}
+      {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.defaultSetting.systemManagedComponentsNodeSelector -}}
+        {{ $windowsDefaultSettingNodeSelector = .Values.global.cattle.windowsCluster.defaultSetting.systemManagedComponentsNodeSelector -}}
+      {{- end -}}
+      {{- if not (kindIs "invalid" .Values.defaultSettings.systemManagedComponentsNodeSelector) -}}
+        {{- $defaultSettingNodeSelector = .Values.defaultSettings.systemManagedComponentsNodeSelector -}}
+      {{- end -}}
+      {{- $nodeSelector := list $windowsDefaultSettingNodeSelector $defaultSettingNodeSelector }}{{ join ";" (compact $nodeSelector) | quote -}}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.systemManagedCSIComponentsResourceLimits) }}
+    system-managed-csi-components-resource-limits: {{ .Values.defaultSettings.systemManagedCSIComponentsResourceLimits | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.priorityClass) }}
+    priority-class: {{ .Values.defaultSettings.priorityClass | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.autoSalvage) }}
+    auto-salvage: {{ .Values.defaultSettings.autoSalvage }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.autoDeletePodWhenVolumeDetachedUnexpectedly) }}
+    auto-delete-pod-when-volume-detached-unexpectedly: {{ .Values.defaultSettings.autoDeletePodWhenVolumeDetachedUnexpectedly }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.blacklistForAutoDeletePodWhenVolumeDetachedUnexpectedly) }}
+    blacklist-for-auto-delete-pod-when-volume-detached-unexpectedly: {{ .Values.defaultSettings.blacklistForAutoDeletePodWhenVolumeDetachedUnexpectedly }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.disableSchedulingOnCordonedNode) }}
+    disable-scheduling-on-cordoned-node: {{ .Values.defaultSettings.disableSchedulingOnCordonedNode }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.replicaZoneSoftAntiAffinity) }}
+    replica-zone-soft-anti-affinity: {{ .Values.defaultSettings.replicaZoneSoftAntiAffinity }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.replicaDiskSoftAntiAffinity) }}
+    replica-disk-soft-anti-affinity: {{ .Values.defaultSettings.replicaDiskSoftAntiAffinity }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.nodeDownPodDeletionPolicy) }}
+    node-down-pod-deletion-policy: {{ .Values.defaultSettings.nodeDownPodDeletionPolicy | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.nodeDrainPolicy) }}
+    node-drain-policy: {{ .Values.defaultSettings.nodeDrainPolicy | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.detachManuallyAttachedVolumesWhenCordoned) }}
+    detach-manually-attached-volumes-when-cordoned: {{ .Values.defaultSettings.detachManuallyAttachedVolumesWhenCordoned }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.replicaReplenishmentWaitInterval) }}
+    replica-replenishment-wait-interval: {{ .Values.defaultSettings.replicaReplenishmentWaitInterval | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.concurrentReplicaRebuildPerNodeLimit) }}
+    concurrent-replica-rebuild-per-node-limit: {{ .Values.defaultSettings.concurrentReplicaRebuildPerNodeLimit | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.rebuildConcurrentSyncLimit) }}
+    rebuild-concurrent-sync-limit: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.rebuildConcurrentSyncLimit }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.concurrentVolumeBackupRestorePerNodeLimit) }}
+    concurrent-volume-backup-restore-per-node-limit: {{ .Values.defaultSettings.concurrentVolumeBackupRestorePerNodeLimit | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.disableRevisionCounter) }}
+    disable-revision-counter: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.disableRevisionCounter }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.systemManagedPodsImagePullPolicy) }}
+    system-managed-pods-image-pull-policy: {{ .Values.defaultSettings.systemManagedPodsImagePullPolicy | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.allowVolumeCreationWithDegradedAvailability) }}
+    allow-volume-creation-with-degraded-availability: {{ .Values.defaultSettings.allowVolumeCreationWithDegradedAvailability }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.autoCleanupSystemGeneratedSnapshot) }}
+    auto-cleanup-system-generated-snapshot: {{ .Values.defaultSettings.autoCleanupSystemGeneratedSnapshot }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.autoCleanupRecurringJobBackupSnapshot) }}
+    auto-cleanup-recurring-job-backup-snapshot: {{ .Values.defaultSettings.autoCleanupRecurringJobBackupSnapshot }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.concurrentAutomaticEngineUpgradePerNodeLimit) }}
+    concurrent-automatic-engine-upgrade-per-node-limit: {{ .Values.defaultSettings.concurrentAutomaticEngineUpgradePerNodeLimit | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.backingImageCleanupWaitInterval) }}
+    backing-image-cleanup-wait-interval: {{ .Values.defaultSettings.backingImageCleanupWaitInterval | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.backingImageRecoveryWaitInterval) }}
+    backing-image-recovery-wait-interval: {{ .Values.defaultSettings.backingImageRecoveryWaitInterval | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.guaranteedInstanceManagerCPU) }}
+    guaranteed-instance-manager-cpu: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.guaranteedInstanceManagerCPU }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.kubernetesClusterAutoscalerEnabled) }}
+    kubernetes-cluster-autoscaler-enabled: {{ .Values.defaultSettings.kubernetesClusterAutoscalerEnabled }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.orphanResourceAutoDeletion) }}
+    orphan-resource-auto-deletion: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.orphanResourceAutoDeletion }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.orphanResourceAutoDeletionGracePeriod) }}
+    orphan-resource-auto-deletion-grace-period: {{ .Values.defaultSettings.orphanResourceAutoDeletionGracePeriod | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.storageNetwork) }}
+    storage-network: {{ .Values.defaultSettings.storageNetwork | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.endpointNetworkForRWXVolume) }}
+    endpoint-network-for-rwx-volume: {{ .Values.defaultSettings.endpointNetworkForRWXVolume | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.deletingConfirmationFlag) }}
+    deleting-confirmation-flag: {{ .Values.defaultSettings.deletingConfirmationFlag }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.engineReplicaTimeout) }}
+    engine-replica-timeout: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.engineReplicaTimeout }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.snapshotDataIntegrity) }}
+    snapshot-data-integrity: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.snapshotDataIntegrity }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.snapshotDataIntegrityImmediateCheckAfterSnapshotCreation) }}
+    snapshot-data-integrity-immediate-check-after-snapshot-creation: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.snapshotDataIntegrityImmediateCheckAfterSnapshotCreation }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.snapshotDataIntegrityCronjob) }}
+    snapshot-data-integrity-cronjob: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.snapshotDataIntegrityCronjob }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.removeSnapshotsDuringFilesystemTrim) }}
+    remove-snapshots-during-filesystem-trim: {{ .Values.defaultSettings.removeSnapshotsDuringFilesystemTrim }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.fastReplicaRebuildEnabled) }}
+    fast-replica-rebuild-enabled: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.fastReplicaRebuildEnabled }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.replicaFileSyncHttpClientTimeout) }}
+    replica-file-sync-http-client-timeout: {{ .Values.defaultSettings.replicaFileSyncHttpClientTimeout | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.longGRPCTimeOut) }}
+    long-grpc-timeout: {{ .Values.defaultSettings.longGRPCTimeOut | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.logLevel) }}
+    log-level: {{ .Values.defaultSettings.logLevel | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.logPath) }}
+    log-path: {{ .Values.defaultSettings.logPath | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.backupCompressionMethod) }}
+    backup-compression-method: {{ .Values.defaultSettings.backupCompressionMethod | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.backupConcurrentLimit) }}
+    backup-concurrent-limit: {{ .Values.defaultSettings.backupConcurrentLimit | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.restoreConcurrentLimit) }}
+    restore-concurrent-limit: {{ .Values.defaultSettings.restoreConcurrentLimit | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.defaultBackupBlockSize) }}
+    default-backup-block-size: {{ .Values.defaultSettings.defaultBackupBlockSize | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.v1DataEngine) }}
+    v1-data-engine: {{ .Values.defaultSettings.v1DataEngine }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.v2DataEngine) }}
+    v2-data-engine: {{ .Values.defaultSettings.v2DataEngine }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.dataEngineHugepageEnabled) }}
+    data-engine-hugepage-enabled: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.dataEngineHugepageEnabled }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.dataEngineMemorySize) }}
+    data-engine-memory-size: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.dataEngineMemorySize }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.allowEmptyNodeSelectorVolume) }}
+    allow-empty-node-selector-volume: {{ .Values.defaultSettings.allowEmptyNodeSelectorVolume }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.allowEmptyDiskSelectorVolume) }}
+    allow-empty-disk-selector-volume: {{ .Values.defaultSettings.allowEmptyDiskSelectorVolume }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.allowCollectingLonghornUsageMetrics) }}
+    allow-collecting-longhorn-usage-metrics: {{ .Values.defaultSettings.allowCollectingLonghornUsageMetrics }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.disableSnapshotPurge) }}
+    disable-snapshot-purge: {{ .Values.defaultSettings.disableSnapshotPurge }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.snapshotMaxCount) }}
+    snapshot-max-count: {{ .Values.defaultSettings.snapshotMaxCount | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.dataEngineLogLevel) }}
+    data-engine-log-level: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.dataEngineLogLevel }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.dataEngineLogFlags) }}
+    data-engine-log-flags: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.dataEngineLogFlags }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.freezeFilesystemForSnapshot) }}
+    freeze-filesystem-for-snapshot: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.freezeFilesystemForSnapshot }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.autoCleanupSnapshotWhenDeleteBackup) }}
+    auto-cleanup-when-delete-backup: {{ .Values.defaultSettings.autoCleanupSnapshotWhenDeleteBackup }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.autoCleanupSnapshotAfterOnDemandBackupCompleted) }}
+    auto-cleanup-snapshot-after-on-demand-backup-completed: {{ .Values.defaultSettings.autoCleanupSnapshotAfterOnDemandBackupCompleted }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.rwxVolumeFastFailover) }}
+    rwx-volume-fast-failover: {{ .Values.defaultSettings.rwxVolumeFastFailover}}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.offlineReplicaRebuilding) }}
+    offline-replica-rebuilding: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.offlineReplicaRebuilding }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.dataEngineCPUMask) }}
+    data-engine-cpu-mask: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.dataEngineCPUMask }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.replicaRebuildingBandwidthLimit) }}
+    replica-rebuilding-bandwidth-limit: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.replicaRebuildingBandwidthLimit }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.replicaRebuildingBandwidthLimit) }}
+    default-ublk-queue-depth: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.defaultUblkQueueDepth }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.replicaRebuildingBandwidthLimit) }}
+    default-ublk-number-of-queue: {{ include "longhorn.multiTypeSetting" .Values.defaultSettings.defaultUblkNumberOfQueue }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.instanceManagerPodLivenessProbeTimeout) }}
+    instance-manager-pod-liveness-probe-timeout: {{ .Values.defaultSettings.instanceManagerPodLivenessProbeTimeout | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.snapshotHeavyTaskConcurrentLimit) }}
+    snapshot-heavy-task-concurrent-limit: {{ .Values.defaultSettings.snapshotHeavyTaskConcurrentLimit | quote }}
+    {{- end }}
+    {{- if not (kindIs "invalid" .Values.defaultSettings.nodeDiskHealthMonitoring) }}
+    node-disk-health-monitoring: {{ .Values.defaultSettings.nameodeDiskHealthMonitoring }}
+    {{- end }}

--- a/manifests/core/longhorn/templates/deployment-driver.yaml
+++ b/manifests/core/longhorn/templates/deployment-driver.yaml
@@ -1,0 +1,152 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: longhorn-driver-deployer
+  namespace: {{ include "release_namespace" . }}
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: longhorn-driver-deployer
+  template:
+    metadata:
+      labels: {{- include "longhorn.labels" . | nindent 8 }}
+        app: longhorn-driver-deployer
+    spec:
+      initContainers:
+        - name: wait-longhorn-manager
+          image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+          command: ['sh', '-c', 'while [ $(curl -m 1 -s -o /dev/null -w "%{http_code}" http://longhorn-backend:9500/v1) != "200" ]; do echo waiting; sleep 2; done']
+      containers:
+        - name: longhorn-driver-deployer
+          image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+          - longhorn-manager
+          - -d
+          {{- if eq .Values.longhornDriver.log.format "json" }}
+          - -j
+          {{- end }}
+          - deploy-driver
+          - --manager-image
+          - "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}"
+          - --manager-url
+          - http://longhorn-backend:9500/v1
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
+          {{- if .Values.csi.kubeletRootDir }}
+          - name: KUBELET_ROOT_DIR
+            value: {{ .Values.csi.kubeletRootDir }}
+          {{- end }}
+          {{- if .Values.csi.podAntiAffinityPreset }}
+          - name: CSI_POD_ANTI_AFFINITY_PRESET
+            value: {{ .Values.csi.podAntiAffinityPreset }}
+          {{- end }}
+          {{- if and .Values.image.csi.attacher.repository .Values.image.csi.attacher.tag }}
+          - name: CSI_ATTACHER_IMAGE
+            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.attacher.registry) }}{{ . }}/{{ end }}{{ .Values.image.csi.attacher.repository }}:{{ .Values.image.csi.attacher.tag }}"
+          {{- end }}
+          {{- if and .Values.image.csi.provisioner.repository .Values.image.csi.provisioner.tag }}
+          - name: CSI_PROVISIONER_IMAGE
+            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.provisioner.registry) }}{{ . }}/{{ end }}{{ .Values.image.csi.provisioner.repository }}:{{ .Values.image.csi.provisioner.tag }}"
+          {{- end }}
+          {{- if and .Values.image.csi.nodeDriverRegistrar.repository .Values.image.csi.nodeDriverRegistrar.tag }}
+          - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
+            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.nodeDriverRegistrar.registry) }}{{ . }}/{{ end }}{{ .Values.image.csi.nodeDriverRegistrar.repository }}:{{ .Values.image.csi.nodeDriverRegistrar.tag }}"
+          {{- end }}
+          {{- if and .Values.image.csi.resizer.repository .Values.image.csi.resizer.tag }}
+          - name: CSI_RESIZER_IMAGE
+            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.resizer.registry) }}{{ . }}/{{ end }}{{ .Values.image.csi.resizer.repository }}:{{ .Values.image.csi.resizer.tag }}"
+          {{- end }}
+          {{- if and .Values.image.csi.snapshotter.repository .Values.image.csi.snapshotter.tag }}
+          - name: CSI_SNAPSHOTTER_IMAGE
+            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.snapshotter.registry) }}{{ . }}/{{ end }}{{ .Values.image.csi.snapshotter.repository }}:{{ .Values.image.csi.snapshotter.tag }}"
+          {{- end }}
+          {{- if and .Values.image.csi.livenessProbe.repository .Values.image.csi.livenessProbe.tag }}
+          - name: CSI_LIVENESS_PROBE_IMAGE
+            value: "{{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.csi.livenessProbe.registry) }}{{ . }}/{{ end }}{{ .Values.image.csi.livenessProbe.repository }}:{{ .Values.image.csi.livenessProbe.tag }}"
+          {{- end }}
+          {{- if .Values.csi.attacherReplicaCount }}
+          - name: CSI_ATTACHER_REPLICA_COUNT
+            value: {{ .Values.csi.attacherReplicaCount | quote }}
+          {{- end }}
+          {{- if .Values.csi.provisionerReplicaCount }}
+          - name: CSI_PROVISIONER_REPLICA_COUNT
+            value: {{ .Values.csi.provisionerReplicaCount | quote }}
+          {{- end }}
+          {{- if .Values.csi.resizerReplicaCount }}
+          - name: CSI_RESIZER_REPLICA_COUNT
+            value: {{ .Values.csi.resizerReplicaCount | quote }}
+          {{- end }}
+          {{- if .Values.csi.snapshotterReplicaCount }}
+          - name: CSI_SNAPSHOTTER_REPLICA_COUNT
+            value: {{ .Values.csi.snapshotterReplicaCount | quote }}
+          {{- end }}
+          {{- if .Values.enableGoCoverDir }}
+          - name: GOCOVERDIR
+            value: /go-cover-dir/
+          volumeMounts:
+          - name: go-cover-dir
+            mountPath: /go-cover-dir/
+          {{- end }}
+          {{- include "longhorn.timezoneEnv" . | nindent 10 }}
+
+      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
+      imagePullSecrets:
+        {{- $imagePullSecrets := list }}
+        {{- if kindIs "string" . }}
+          {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+        {{- else }}
+          {{- range . }}
+            {{- if kindIs "string" . }}
+                {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+            {{- else }}
+                {{- $imagePullSecrets = append $imagePullSecrets . }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- toYaml $imagePullSecrets | nindent 8 }}
+      {{- end }}
+      {{- if .Values.longhornDriver.priorityClass }}
+      priorityClassName: {{ .Values.longhornDriver.priorityClass | quote }}
+      {{- end }}
+      {{- if or .Values.global.tolerations .Values.longhornDriver.tolerations .Values.global.cattle.windowsCluster.enabled }}
+      tolerations:
+        {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.tolerations }}
+{{ toYaml .Values.global.cattle.windowsCluster.tolerations | indent 6 }}
+        {{- end }}
+        {{- if or .Values.global.tolerations .Values.longhornDriver.tolerations }}
+{{ default .Values.global.tolerations .Values.longhornDriver.tolerations | toYaml | indent 6 }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.global.nodeSelector .Values.longhornDriver.nodeSelector .Values.global.cattle.windowsCluster.enabled }}
+      nodeSelector:
+        {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.nodeSelector }}
+{{ toYaml .Values.global.cattle.windowsCluster.nodeSelector | indent 8 }}
+        {{- end }}
+        {{- if or .Values.global.nodeSelector .Values.longhornDriver.nodeSelector }}
+{{ default .Values.global.nodeSelector .Values.longhornDriver.nodeSelector | toYaml | indent 8 }}
+        {{- end }}
+      {{- end }}
+      serviceAccountName: longhorn-service-account
+      securityContext:
+        runAsUser: 0
+      {{- if .Values.enableGoCoverDir }}
+      volumes:
+      - name: go-cover-dir
+        hostPath:
+          path: /go-cover-dir/
+          type: DirectoryOrCreate
+      {{- end }}

--- a/manifests/core/longhorn/templates/deployment-ui.yaml
+++ b/manifests/core/longhorn/templates/deployment-ui.yaml
@@ -1,0 +1,199 @@
+{{- if .Values.openshift.enabled }}
+{{- if .Values.openshift.ui.route }}
+# https://github.com/openshift/oauth-proxy/blob/master/contrib/sidecar.yaml
+# Create a proxy service account and ensure it will use the route "proxy"
+# Create a secure connection to the proxy via a route
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-ui
+  name: {{ .Values.openshift.ui.route }}
+  namespace: {{ include "release_namespace" . }}
+spec:
+  to:
+    kind: Service
+    name: longhorn-ui
+  tls:
+    termination: reencrypt
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-ui
+  name: longhorn-ui
+  namespace: {{ include "release_namespace" . }}
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: longhorn-ui-tls
+spec:
+  ports:
+  - name: longhorn-ui
+    port: {{ .Values.openshift.ui.port | default 443 }}
+    targetPort: {{ .Values.openshift.ui.proxy | default 8443 }}
+  selector:
+    app: longhorn-ui
+---
+{{- end }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-ui
+  name: longhorn-ui
+  namespace: {{ include "release_namespace" . }}
+spec:
+  replicas: {{ .Values.longhornUI.replicas }}
+  selector:
+    matchLabels:
+      app: longhorn-ui
+  template:
+    metadata:
+      labels: {{- include "longhorn.labels" . | nindent 8 }}
+        app: longhorn-ui
+    spec:
+      serviceAccountName: longhorn-ui-service-account
+      affinity:
+      {{- toYaml .Values.longhornUI.affinity | nindent 8 }}
+      containers:
+      {{- if .Values.openshift.enabled }}
+      {{- if .Values.openshift.ui.route }}
+      - name: oauth-proxy
+        {{- if .Values.image.openshift.oauthProxy.repository }}
+        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.openshift.oauthProxy.registry) }}{{ . }}/{{ end }}{{ .Values.image.openshift.oauthProxy.repository }}:{{ .Values.image.openshift.oauthProxy.tag }}
+        {{- else }}
+        image: ""
+        {{- end }}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: {{ .Values.openshift.ui.proxy | default 8443 }}
+          name: public
+        args:
+        - --https-address=:{{ .Values.openshift.ui.proxy | default 8443 }}
+        - --provider=openshift
+        - --openshift-service-account=longhorn-ui-service-account
+        - --upstream=http://localhost:8000
+        - --tls-cert=/etc/tls/private/tls.crt
+        - --tls-key=/etc/tls/private/tls.key
+        - --cookie-secret=SECRET
+        - --openshift-sar={"namespace":"{{ include "release_namespace" . }}","group":"longhorn.io","resource":"setting","verb":"delete"}
+        volumeMounts:
+          - mountPath: /etc/tls/private
+            name: longhorn-ui-tls
+      {{- end }}
+      {{- end }}
+      - name: longhorn-ui
+        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.ui.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.ui.repository }}:{{ .Values.image.longhorn.ui.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        volumeMounts:
+        - name: nginx-cache
+          mountPath: /var/cache/nginx/
+        - name: nginx-config
+          mountPath: /var/config/nginx/
+        - name: var-run
+          mountPath: /var/run/
+        ports:
+        - containerPort: 8000
+          name: http
+        env:
+          - name: LONGHORN_MANAGER_IP
+            value: "http://longhorn-backend:9500"
+          - name: LONGHORN_UI_PORT
+            value: "8000"
+          {{- include "longhorn.timezoneEnv" . | nindent 10 }}
+      volumes:
+      {{- if .Values.openshift.enabled }}
+      {{- if .Values.openshift.ui.route }}
+      - name: longhorn-ui-tls
+        secret:
+          secretName: longhorn-ui-tls
+      {{- end }}
+      {{- end }}
+      - emptyDir: {}
+        name: nginx-cache
+      - emptyDir: {}
+        name: nginx-config
+      - emptyDir: {}
+        name: var-run
+      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
+      imagePullSecrets:
+        {{- $imagePullSecrets := list }}
+        {{- if kindIs "string" . }}
+          {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+        {{- else }}
+          {{- range . }}
+            {{- if kindIs "string" . }}
+                {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+            {{- else }}
+                {{- $imagePullSecrets = append $imagePullSecrets . }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- toYaml $imagePullSecrets | nindent 8 }}
+      {{- end }}
+      {{- if .Values.longhornUI.priorityClass }}
+      priorityClassName: {{ .Values.longhornUI.priorityClass | quote }}
+      {{- end }}
+      {{- if or .Values.global.tolerations .Values.longhornUI.tolerations .Values.global.cattle.windowsCluster.enabled }}
+      tolerations:
+        {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.tolerations }}
+{{ toYaml .Values.global.cattle.windowsCluster.tolerations | indent 6 }}
+        {{- end }}
+        {{- if or .Values.global.tolerations .Values.longhornUI.tolerations }}
+{{ default .Values.global.tolerations .Values.longhornUI.tolerations | toYaml | indent 6 }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.global.nodeSelector .Values.longhornUI.nodeSelector .Values.global.cattle.windowsCluster.enabled }}
+      nodeSelector:
+        {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.nodeSelector }}
+{{ toYaml .Values.global.cattle.windowsCluster.nodeSelector | indent 8 }}
+        {{- end }}
+        {{- if or .Values.global.nodeSelector .Values.longhornUI.nodeSelector }}
+{{ default .Values.global.nodeSelector .Values.longhornUI.nodeSelector | toYaml | indent 8 }}
+        {{- end }}
+      {{- end }}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-ui
+    {{- if eq .Values.service.ui.type "Rancher-Proxy" }}
+    kubernetes.io/cluster-service: "true"
+    {{- end }}
+    {{- with .Values.service.ui.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: longhorn-frontend
+  namespace: {{ include "release_namespace" . }}
+  {{- with .Values.service.ui.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if eq .Values.service.ui.type "Rancher-Proxy" }}
+  type: ClusterIP
+  {{- else }}
+  type: {{ .Values.service.ui.type }}
+  {{- end }}
+  {{- if and .Values.service.ui.loadBalancerIP (eq .Values.service.ui.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.service.ui.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.service.ui.type "LoadBalancer") .Values.service.ui.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml .Values.service.ui.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  {{- if and (eq .Values.service.ui.type "LoadBalancer") .Values.service.ui.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.service.ui.loadBalancerClass }}
+  {{- end }}
+  selector:
+    app: longhorn-ui
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+    {{- if .Values.service.ui.nodePort }}
+    nodePort: {{ .Values.service.ui.nodePort }}
+    {{- else }}
+    nodePort: null
+    {{- end }}

--- a/manifests/core/longhorn/templates/extra-objects.yaml
+++ b/manifests/core/longhorn/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{- tpl (toYaml . ) $ }}
+{{- end }}

--- a/manifests/core/longhorn/templates/httproute.yaml
+++ b/manifests/core/longhorn/templates/httproute.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.httproute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: longhorn-httproute
+  namespace: {{ include "release_namespace" . }}
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-httproute
+  {{- with .Values.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httproute.parentRefs }}
+  parentRefs:
+    {{- range . }}
+    - group: {{ .group | default "gateway.networking.k8s.io" }}
+      kind: {{ .kind | default "Gateway" }}
+      name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .sectionName }}
+      sectionName: {{ . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- with .Values.httproute.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+  - matches:
+    - path:
+        type: {{ .Values.httproute.pathType | default "PathPrefix" }}
+        value: {{ .Values.httproute.path | default "/" }}
+    backendRefs:
+    - name: longhorn-frontend
+      port: 80
+{{- end }}

--- a/manifests/core/longhorn/templates/ingress.yaml
+++ b/manifests/core/longhorn/templates/ingress.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: longhorn-ingress
+  namespace: {{ include "release_namespace" . }}
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-ingress
+  annotations:
+    {{- if .Values.ingress.secureBackends }}
+    ingress.kubernetes.io/secure-backends: "true"
+    {{- end }}
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
+  rules:
+  - host: {{ .Values.ingress.host }}
+    http:
+      paths:
+        - path: {{ default "" .Values.ingress.path }}
+          pathType: {{ default "ImplementationSpecific" .Values.ingress.pathType }}
+          backend:
+            service:
+              name: longhorn-frontend
+              port:
+                number: 80
+{{- range .Values.ingress.extraHosts }}
+  - host: {{ . }}
+    http:
+      paths:
+        - path: {{ default "" $.Values.ingress.path }}
+          pathType: {{ default "ImplementationSpecific" $.Values.ingress.pathType }}
+          backend:
+            service:
+              name: longhorn-frontend
+              port:
+                number: 80
+{{- end }}
+{{- if .Values.ingress.tls }}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.host }}
+    {{- range .Values.ingress.extraHosts }}
+    - {{ . }}
+    {{- end }}
+    secretName: {{ .Values.ingress.tlsSecret }}
+{{- end }}
+{{- end }}

--- a/manifests/core/longhorn/templates/network-policies/backing-image-data-source-network-policy.yaml
+++ b/manifests/core/longhorn/templates/network-policies/backing-image-data-source-network-policy.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: backing-image-data-source
+  namespace: {{ include "release_namespace" . }}
+spec:
+  podSelector:
+    matchLabels:
+      longhorn.io/component: backing-image-data-source
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: longhorn-manager
+    - podSelector:
+        matchLabels:
+          longhorn.io/component: instance-manager
+    - podSelector:
+        matchLabels:
+          longhorn.io/component: backing-image-manager
+    - podSelector:
+        matchLabels:
+          longhorn.io/component: backing-image-data-source
+{{- end }}

--- a/manifests/core/longhorn/templates/network-policies/backing-image-manager-network-policy.yaml
+++ b/manifests/core/longhorn/templates/network-policies/backing-image-manager-network-policy.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: backing-image-manager
+  namespace: {{ include "release_namespace" . }}
+spec:
+  podSelector:
+    matchLabels:
+      longhorn.io/component: backing-image-manager
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: longhorn-manager
+    - podSelector:
+        matchLabels:
+          longhorn.io/component: instance-manager
+    - podSelector:
+        matchLabels:
+          longhorn.io/component: backing-image-manager
+    - podSelector:
+        matchLabels:
+          longhorn.io/component: backing-image-data-source
+{{- end }}

--- a/manifests/core/longhorn/templates/network-policies/instance-manager-networking.yaml
+++ b/manifests/core/longhorn/templates/network-policies/instance-manager-networking.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: instance-manager
+  namespace: {{ include "release_namespace" . }}
+spec:
+  podSelector:
+    matchLabels:
+      longhorn.io/component: instance-manager
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: longhorn-manager
+    - podSelector:
+        matchLabels:
+          longhorn.io/component: instance-manager
+    - podSelector:
+        matchLabels:
+          longhorn.io/component: backing-image-manager
+    - podSelector:
+        matchLabels:
+          longhorn.io/component: backing-image-data-source
+{{- end }}

--- a/manifests/core/longhorn/templates/network-policies/manager-network-policy.yaml
+++ b/manifests/core/longhorn/templates/network-policies/manager-network-policy.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-manager
+  namespace: {{ include "release_namespace" . }}
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-manager
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: longhorn-manager
+    - podSelector:
+        matchLabels:
+          app: longhorn-ui
+    - podSelector:
+        matchLabels:
+          app: longhorn-csi-plugin
+    - podSelector:
+        matchLabels:
+          longhorn.io/managed-by: longhorn-manager
+        matchExpressions:
+          - { key: recurring-job.longhorn.io, operator: Exists }
+    - podSelector:
+        matchExpressions:
+          - { key: longhorn.io/job-task, operator: Exists }
+    - podSelector:
+        matchLabels:
+          app: longhorn-driver-deployer
+{{- end }}

--- a/manifests/core/longhorn/templates/network-policies/recovery-backend-network-policy.yaml
+++ b/manifests/core/longhorn/templates/network-policies/recovery-backend-network-policy.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-recovery-backend
+  namespace: {{ include "release_namespace" . }}
+spec:
+  podSelector:
+    matchLabels:
+      longhorn.io/recovery-backend: longhorn-recovery-backend
+  policyTypes:
+  - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 9503
+{{- end }}

--- a/manifests/core/longhorn/templates/network-policies/ui-frontend-network-policy.yaml
+++ b/manifests/core/longhorn/templates/network-policies/ui-frontend-network-policy.yaml
@@ -1,0 +1,46 @@
+{{- if and .Values.networkPolicies.enabled .Values.ingress.enabled (not (eq .Values.networkPolicies.type "")) }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-ui-frontend
+  namespace: {{ include "release_namespace" . }}
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-ui
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    {{- if eq .Values.networkPolicies.type "rke1"}}
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-nginx
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/component: controller
+          app.kubernetes.io/instance: ingress-nginx
+          app.kubernetes.io/name: ingress-nginx
+    {{- else if eq .Values.networkPolicies.type "rke2" }}
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/component: controller
+          app.kubernetes.io/instance: rke2-ingress-nginx
+          app.kubernetes.io/name: rke2-ingress-nginx
+    {{- else if eq .Values.networkPolicies.type "k3s" }}
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: traefik
+    ports:
+      - port: 8000
+        protocol: TCP
+      - port: 80
+        protocol: TCP
+    {{- end }}
+{{- end }}

--- a/manifests/core/longhorn/templates/network-policies/webhook-network-policy.yaml
+++ b/manifests/core/longhorn/templates/network-policies/webhook-network-policy.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-admission-webhook
+  namespace: {{ include "release_namespace" . }}
+spec:
+  podSelector:
+    matchLabels:
+      longhorn.io/admission-webhook: longhorn-admission-webhook
+  policyTypes:
+  - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 9502
+{{- end }}

--- a/manifests/core/longhorn/templates/postupgrade-job.yaml
+++ b/manifests/core/longhorn/templates/postupgrade-job.yaml
@@ -1,0 +1,69 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+  name: longhorn-post-upgrade
+  namespace: {{ include "release_namespace" . }}
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+spec:
+  activeDeadlineSeconds: 900
+  backoffLimit: 1
+  template:
+    metadata:
+      name: longhorn-post-upgrade
+      labels: {{- include "longhorn.labels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: longhorn-post-upgrade
+        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - longhorn-manager
+        - post-upgrade
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- include "longhorn.timezoneEnv" . | nindent 8 }}
+      restartPolicy: OnFailure
+      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
+      imagePullSecrets:
+        {{- $imagePullSecrets := list }}
+        {{- if kindIs "string" . }}
+          {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+        {{- else }}
+          {{- range . }}
+            {{- if kindIs "string" . }}
+                {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+            {{- else }}
+                {{- $imagePullSecrets = append $imagePullSecrets . }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- toYaml $imagePullSecrets | nindent 8 }}
+      {{- end }}
+      {{- if .Values.longhornManager.priorityClass }}
+      priorityClassName: {{ .Values.longhornManager.priorityClass | quote }}
+      {{- end }}
+      serviceAccountName: longhorn-service-account
+      {{- if or .Values.global.tolerations .Values.longhornManager.tolerations .Values.global.cattle.windowsCluster.enabled }}
+      tolerations:
+        {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.tolerations }}
+{{ toYaml .Values.global.cattle.windowsCluster.tolerations | indent 6 }}
+        {{- end }}
+        {{- if or .Values.global.tolerations .Values.longhornManager.tolerations }}
+{{ default .Values.global.tolerations .Values.longhornManager.tolerations | toYaml | indent 6 }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.global.nodeSelector .Values.longhornManager.nodeSelector .Values.global.cattle.windowsCluster.enabled }}
+      nodeSelector:
+        {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.nodeSelector }}
+{{ toYaml .Values.global.cattle.windowsCluster.nodeSelector | indent 8 }}
+        {{- end }}
+        {{- if or .Values.global.nodeSelector .Values.longhornManager.nodeSelector }}
+{{ default .Values.global.nodeSelector .Values.longhornManager.nodeSelector | toYaml | indent 8 }}
+        {{- end }}
+      {{- end }}

--- a/manifests/core/longhorn/templates/preupgrade-job.yaml
+++ b/manifests/core/longhorn/templates/preupgrade-job.yaml
@@ -1,0 +1,77 @@
+{{- if and .Values.preUpgradeChecker.jobEnabled .Values.preUpgradeChecker.upgradeVersionCheck}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation,hook-failed
+  name: longhorn-pre-upgrade
+  namespace: {{ include "release_namespace" . }}
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+spec:
+  activeDeadlineSeconds: 900
+  backoffLimit: 1
+  template:
+    metadata:
+      name: longhorn-pre-upgrade
+      labels: {{- include "longhorn.labels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: longhorn-pre-upgrade
+        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          privileged: true
+        command:
+        - longhorn-manager
+        - pre-upgrade
+        volumeMounts:
+        - name: proc
+          mountPath: /host/proc/
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- include "longhorn.timezoneEnv" . | nindent 8 }}
+      volumes:
+      - name: proc
+        hostPath:
+          path: /proc/
+      restartPolicy: OnFailure
+      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
+      imagePullSecrets:
+        {{- $imagePullSecrets := list }}
+        {{- if kindIs "string" . }}
+          {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+        {{- else }}
+          {{- range . }}
+            {{- if kindIs "string" . }}
+                {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+            {{- else }}
+                {{- $imagePullSecrets = append $imagePullSecrets . }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- toYaml $imagePullSecrets | nindent 8 }}
+      {{- end }}
+      serviceAccountName: longhorn-service-account
+      {{- if or .Values.global.tolerations .Values.longhornManager.tolerations .Values.global.cattle.windowsCluster.enabled }}
+      tolerations:
+        {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.tolerations }}
+{{ toYaml .Values.global.cattle.windowsCluster.tolerations | indent 6 }}
+        {{- end }}
+        {{- if or .Values.global.tolerations .Values.longhornManager.tolerations }}
+{{ default .Values.global.tolerations .Values.longhornManager.tolerations | toYaml | indent 6 }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.global.nodeSelector .Values.longhornManager.nodeSelector .Values.global.cattle.windowsCluster.enabled }}
+      nodeSelector:
+        {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.nodeSelector }}
+{{ toYaml .Values.global.cattle.windowsCluster.nodeSelector | indent 8 }}
+        {{- end }}
+        {{- if or .Values.global.nodeSelector .Values.longhornManager.nodeSelector }}
+{{ default .Values.global.nodeSelector .Values.longhornManager.nodeSelector | toYaml | indent 8 }}
+        {{- end }}
+      {{- end }}
+{{- end }}

--- a/manifests/core/longhorn/templates/preupgrade-job.yaml
+++ b/manifests/core/longhorn/templates/preupgrade-job.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation,hook-failed
+    ignore-check.kube-linter.io/privileged-container: "Needs privileged access for storage"
   name: longhorn-pre-upgrade
   namespace: {{ include "release_namespace" . }}
   labels: {{- include "longhorn.labels" . | nindent 4 }}
@@ -15,6 +16,8 @@ spec:
     metadata:
       name: longhorn-pre-upgrade
       labels: {{- include "longhorn.labels" . | nindent 8 }}
+      annotations:
+        ignore-check.kube-linter.io/privileged-container: "Needs privileged access for storage"
     spec:
       containers:
       - name: longhorn-pre-upgrade

--- a/manifests/core/longhorn/templates/priorityclass.yaml
+++ b/manifests/core/longhorn/templates/priorityclass.yaml
@@ -1,0 +1,9 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: "longhorn-critical"
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+description: "Ensure Longhorn pods have the highest priority to prevent any unexpected eviction by the Kubernetes scheduler under node pressure"
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+value: 1000000000

--- a/manifests/core/longhorn/templates/psp.yaml
+++ b/manifests/core/longhorn/templates/psp.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.enablePSP }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: longhorn-psp
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  requiredDropCapabilities:
+  - NET_RAW
+  allowedCapabilities:
+  - SYS_ADMIN
+  hostNetwork: false
+  hostIPC: false
+  hostPID: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - secret
+  - projected
+  - hostPath
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: longhorn-psp-role
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+  namespace: {{ include "release_namespace" . }}
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - longhorn-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: longhorn-psp-binding
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+  namespace: {{ include "release_namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: longhorn-psp-role
+subjects:
+- kind: ServiceAccount
+  name: longhorn-service-account
+  namespace: {{ include "release_namespace" . }}
+- kind: ServiceAccount
+  name: default
+  namespace: {{ include "release_namespace" . }}
+{{- end }}

--- a/manifests/core/longhorn/templates/registry-secret.yaml
+++ b/manifests/core/longhorn/templates/registry-secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.privateRegistry.createSecret }}
+{{- if .Values.privateRegistry.registrySecret }}
+{{- if not (kindIs "string" .Values.privateRegistry.registrySecret) }}
+{{- fail "The privateRegistry.registrySecret value must be a string" }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.privateRegistry.registrySecret }}
+  namespace: {{ include "release_namespace" . }}
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "secret" . }}
+{{- end }}
+{{- end }}

--- a/manifests/core/longhorn/templates/role.yaml
+++ b/manifests/core/longhorn/templates/role.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "longhorn.name" . }}
+  namespace: {{ include "release_namespace" . }}
+  labels:
+    {{- include "longhorn.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log", "events", "secrets", "services", "endpoints", "configmaps", "serviceaccounts", "persistentvolumeclaims", "persistentvolumeclaims/status"]
+  verbs: ["*"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets", "deployments", "statefulsets", "replicasets"]
+  verbs: ["*"]
+- apiGroups: ["batch"]
+  resources: ["jobs", "cronjobs"]
+  verbs: ["*"]
+- apiGroups: ["policy"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["*"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["*"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["*"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["*"]

--- a/manifests/core/longhorn/templates/rolebinding.yaml
+++ b/manifests/core/longhorn/templates/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "longhorn.name" . }}
+  namespace: {{ include "release_namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "longhorn.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: longhorn-service-account
+  namespace: {{ include "release_namespace" . }}

--- a/manifests/core/longhorn/templates/serviceaccount.yaml
+++ b/manifests/core/longhorn/templates/serviceaccount.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-service-account
+  namespace: {{ include "release_namespace" . }}
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-ui-service-account
+  namespace: {{ include "release_namespace" . }}
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.openshift.enabled }}
+  {{- if .Values.openshift.ui.route }}
+  {{- if not .Values.serviceAccount.annotations }}
+  annotations:
+  {{- end }}
+    serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"longhorn-ui"}}'
+  {{- end }}
+  {{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-support-bundle
+  namespace: {{ include "release_namespace" . }}
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/manifests/core/longhorn/templates/servicemonitor.yaml
+++ b/manifests/core/longhorn/templates/servicemonitor.yaml
@@ -1,0 +1,40 @@
+{{- if  .Values.metrics.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: longhorn-prometheus-servicemonitor
+  namespace: {{ include "release_namespace" . }}
+  labels:
+    {{- include "longhorn.labels" . | nindent 4 }}
+    name: longhorn-prometheus-servicemonitor
+    {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.metrics.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: longhorn-manager
+  namespaceSelector:
+    matchNames:
+    - {{ include "release_namespace" . }}
+  endpoints:
+  - port: manager
+    {{- with .Values.metrics.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/manifests/core/longhorn/templates/services.yaml
+++ b/manifests/core/longhorn/templates/services.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-admission-webhook
+  name: longhorn-admission-webhook
+  namespace: {{ include "release_namespace" . }}
+spec:
+  type: ClusterIP
+  selector:
+    longhorn.io/admission-webhook: longhorn-admission-webhook
+  ports:
+  - name: admission-webhook
+    port: 9502
+    targetPort: admission-wh
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+    app: longhorn-recovery-backend
+  name: longhorn-recovery-backend
+  namespace: {{ include "release_namespace" . }}
+spec:
+  type: ClusterIP
+  selector:
+    longhorn.io/recovery-backend: longhorn-recovery-backend
+  ports:
+  - name: recovery-backend
+    port: 9503
+    targetPort: recov-backend

--- a/manifests/core/longhorn/templates/storageclass.yaml
+++ b/manifests/core/longhorn/templates/storageclass.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: longhorn-storageclass
+  namespace: {{ include "release_namespace" . }}
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+data:
+  storageclass.yaml: |
+    kind: StorageClass
+    apiVersion: storage.k8s.io/v1
+    metadata:
+      name: longhorn
+      annotations:
+        storageclass.kubernetes.io/is-default-class: {{ .Values.persistence.defaultClass | quote }}
+    provisioner: driver.longhorn.io
+    allowVolumeExpansion: true
+    reclaimPolicy: "{{ .Values.persistence.reclaimPolicy }}"
+    volumeBindingMode: {{ .Values.persistence.volumeBindingMode | default "Immediate" }}
+    parameters:
+      numberOfReplicas: "{{ .Values.persistence.defaultClassReplicaCount }}"
+      staleReplicaTimeout: "30"
+      fromBackup: ""
+      {{- if .Values.persistence.defaultFsType }}
+      fsType: "{{ .Values.persistence.defaultFsType }}"
+      {{- end }}
+      {{- if .Values.persistence.defaultMkfsParams }}
+      mkfsParams: "{{ .Values.persistence.defaultMkfsParams }}"
+      {{- end }}
+      {{- if .Values.persistence.migratable }}
+      migratable: "{{ .Values.persistence.migratable }}"
+      {{- end }}    
+      {{- if .Values.persistence.nfsOptions }}
+      nfsOptions: "{{ .Values.persistence.nfsOptions }}"
+      {{- end }}    
+      {{- if .Values.persistence.backingImage.enable }}
+      backingImage: {{ .Values.persistence.backingImage.name }}
+      backingImageDataSourceType: {{ .Values.persistence.backingImage.dataSourceType }}
+      backingImageDataSourceParameters: {{ .Values.persistence.backingImage.dataSourceParameters }}
+      backingImageChecksum: {{ .Values.persistence.backingImage.expectedChecksum }}
+      {{- end }}
+      {{- if .Values.persistence.recurringJobSelector.enable }}
+      recurringJobSelector: '{{ .Values.persistence.recurringJobSelector.jobList }}'
+      {{- end }}
+      dataLocality: {{ .Values.persistence.defaultDataLocality | quote }}
+      {{- if .Values.persistence.defaultDiskSelector.enable }}
+      diskSelector: "{{ .Values.persistence.defaultDiskSelector.selector }}"
+      {{- end }}
+      {{- if .Values.persistence.defaultNodeSelector.enable }}
+      nodeSelector: "{{ .Values.persistence.defaultNodeSelector.selector }}"
+      {{- end }}
+      {{- if .Values.persistence.unmapMarkSnapChainRemoved }}
+      unmapMarkSnapChainRemoved: "{{ .Values.persistence.unmapMarkSnapChainRemoved }}"
+      {{- end }}
+      {{- if .Values.persistence.disableRevisionCounter }}
+      disableRevisionCounter: "{{ .Values.persistence.disableRevisionCounter }}"
+      dataEngine: "{{ .Values.persistence.dataEngine }}"
+      {{- end }}
+      {{- if .Values.persistence.backupTargetName }}
+      backupTargetName: "{{ .Values.persistence.backupTargetName }}"
+      {{- end }}

--- a/manifests/core/longhorn/templates/tls-secrets.yaml
+++ b/manifests/core/longhorn/templates/tls-secrets.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  namespace: {{ include "release_namespace" $ }}
+  labels: {{- include "longhorn.labels" $ | nindent 4 }}
+    app: longhorn
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}

--- a/manifests/core/longhorn/templates/uninstall-job.yaml
+++ b/manifests/core/longhorn/templates/uninstall-job.yaml
@@ -1,0 +1,70 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: longhorn-uninstall
+  namespace: {{ include "release_namespace" . }}
+  labels: {{- include "longhorn.labels" . | nindent 4 }}
+spec:
+  activeDeadlineSeconds: 900
+  backoffLimit: 1
+  template:
+    metadata:
+      name: longhorn-uninstall
+      labels: {{- include "longhorn.labels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: longhorn-uninstall
+        image: {{ with (coalesce .Values.global.imageRegistry (include "registry_url" .) .Values.image.longhorn.manager.registry) }}{{ . }}/{{ end }}{{ .Values.image.longhorn.manager.repository }}:{{ .Values.image.longhorn.manager.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - longhorn-manager
+        - uninstall
+        - --force
+        env:
+        - name: LONGHORN_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- include "longhorn.timezoneEnv" . | nindent 8 }}
+      restartPolicy: Never
+      {{- with (coalesce .Values.global.imagePullSecrets .Values.privateRegistry.registrySecret) }}
+      imagePullSecrets:
+        {{- $imagePullSecrets := list }}
+        {{- if kindIs "string" . }}
+          {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+        {{- else }}
+          {{- range . }}
+            {{- if kindIs "string" . }}
+                {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+            {{- else }}
+                {{- $imagePullSecrets = append $imagePullSecrets . }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- toYaml $imagePullSecrets | nindent 8 }}
+      {{- end }}
+      {{- if .Values.longhornManager.priorityClass }}
+      priorityClassName: {{ .Values.longhornManager.priorityClass | quote }}
+      {{- end }}
+      serviceAccountName: longhorn-service-account
+      {{- if or .Values.global.tolerations .Values.longhornManager.tolerations .Values.global.cattle.windowsCluster.enabled }}
+      tolerations:
+        {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.tolerations }}
+{{ toYaml .Values.global.cattle.windowsCluster.tolerations | indent 6 }}
+        {{- end }}
+        {{- if or .Values.global.tolerations .Values.longhornManager.tolerations }}
+{{ default .Values.global.tolerations .Values.longhornManager.tolerations | toYaml | indent 6 }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.global.nodeSelector .Values.longhornManager.nodeSelector .Values.global.cattle.windowsCluster.enabled }}
+      nodeSelector:
+        {{- if and .Values.global.cattle.windowsCluster.enabled .Values.global.cattle.windowsCluster.nodeSelector }}
+{{ toYaml .Values.global.cattle.windowsCluster.nodeSelector | indent 8 }}
+        {{- end }}
+        {{- if or .Values.global.nodeSelector .Values.longhornManager.nodeSelector }}
+{{ default .Values.global.nodeSelector .Values.longhornManager.nodeSelector | toYaml | indent 8 }}
+        {{- end }}
+      {{- end }}

--- a/manifests/core/longhorn/templates/validate-psp-install.yaml
+++ b/manifests/core/longhorn/templates/validate-psp-install.yaml
@@ -1,0 +1,7 @@
+#{{- if gt (len (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "")) 0 -}}
+#{{- if .Values.enablePSP }}
+#{{- if not (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+#{{- fail "The target cluster does not have the PodSecurityPolicy API resource. Please disable PSPs in this chart before proceeding." -}}
+#{{- end }}
+#{{- end }}
+#{{- end }}

--- a/manifests/core/longhorn/values.yaml
+++ b/manifests/core/longhorn/values.yaml
@@ -1,0 +1,661 @@
+# Default values for longhorn.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+global:
+  # -- Global override for container image registry.
+  imageRegistry: "docker.io"
+  # -- Global override for image pull secrets for container registry.
+  imagePullSecrets: []
+  # -- Set container timezone (TZ env) for all Longhorn workloads. Leave empty to use container default.
+  timezone: ""
+  # -- Toleration for nodes allowed to run user-deployed components such as Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer.
+  tolerations: []
+  # -- Node selector for nodes allowed to run user-deployed components such as Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer.
+  nodeSelector: {}
+  cattle:
+    # -- Default system registry.
+    systemDefaultRegistry: ""
+    windowsCluster:
+      # -- Setting that allows Longhorn to run on a Rancher Windows cluster.
+      enabled: false
+      # -- Toleration for Linux nodes that can run user-deployed Longhorn components.
+      tolerations:
+        - key: "cattle.io/os"
+          value: "linux"
+          effect: "NoSchedule"
+          operator: "Equal"
+      # -- Node selector for Linux nodes that can run user-deployed Longhorn components.
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      defaultSetting:
+        # -- Toleration for system-managed Longhorn components.
+        taintToleration: cattle.io/os=linux:NoSchedule
+        # -- Node selector for system-managed Longhorn components.
+        systemManagedComponentsNodeSelector: kubernetes.io/os:linux
+networkPolicies:
+  # -- Setting that allows you to enable network policies that control access to Longhorn pods.
+  enabled: false
+  # -- Distribution that determines the policy for allowing access for an ingress. (Options: "k3s", "rke2", "rke1")
+  type: "k3s"
+image:
+  longhorn:
+    engine:
+      # -- Registry for the Longhorn Engine image.
+      registry: ""
+      # -- Repository for the Longhorn Engine image.
+      repository: longhornio/longhorn-engine
+      # -- Tag for the Longhorn Engine image.
+      tag: v1.11.0
+    manager:
+      # -- Registry for the Longhorn Manager image.
+      registry: ""
+      # -- Repository for the Longhorn Manager image.
+      repository: longhornio/longhorn-manager
+      # -- Tag for the Longhorn Manager image.
+      tag: v1.11.0
+    ui:
+      # -- Registry for the Longhorn UI image.
+      registry: ""
+      # -- Repository for the Longhorn UI image.
+      repository: longhornio/longhorn-ui
+      # -- Tag for the Longhorn UI image.
+      tag: v1.11.0
+    instanceManager:
+      # -- Registry for the Longhorn Instance Manager image.
+      registry: ""
+      # -- Repository for the Longhorn Instance Manager image.
+      repository: longhornio/longhorn-instance-manager
+      # -- Tag for the Longhorn Instance Manager image.
+      tag: v1.11.0
+    shareManager:
+      # -- Registry for the Longhorn Share Manager image.
+      registry: ""
+      # -- Repository for the Longhorn Share Manager image.
+      repository: longhornio/longhorn-share-manager
+      # -- Tag for the Longhorn Share Manager image.
+      tag: v1.11.0
+    backingImageManager:
+      # -- Registry for the Backing Image Manager image. When unspecified, Longhorn uses the default value.
+      registry: ""
+      # -- Repository for the Backing Image Manager image. When unspecified, Longhorn uses the default value.
+      repository: longhornio/backing-image-manager
+      # -- Tag for the Backing Image Manager image. When unspecified, Longhorn uses the default value.
+      tag: v1.11.0
+    supportBundleKit:
+      # -- Registry for the Longhorn Support Bundle Manager image.
+      registry: ""
+      # -- Repository for the Longhorn Support Bundle Manager image.
+      repository: longhornio/support-bundle-kit
+      # -- Tag for the Longhorn Support Bundle Manager image.
+      tag: v0.0.79
+  csi:
+    attacher:
+      # -- Registry for the CSI attacher image. When unspecified, Longhorn uses the default value.
+      registry: ""
+      # -- Repository for the CSI attacher image. When unspecified, Longhorn uses the default value.
+      repository: longhornio/csi-attacher
+      # -- Tag for the CSI attacher image. When unspecified, Longhorn uses the default value.
+      tag: v4.10.0-20251226
+    provisioner:
+      # -- Registry for the CSI Provisioner image. When unspecified, Longhorn uses the default value.
+      registry: ""
+      # -- Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value.
+      repository: longhornio/csi-provisioner
+      # -- Tag for the CSI Provisioner image. When unspecified, Longhorn uses the default value.
+      tag: v5.3.0-20251226
+    nodeDriverRegistrar:
+      # -- Registry for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value.
+      registry: ""
+      # -- Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value.
+      repository: longhornio/csi-node-driver-registrar
+      # -- Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value.
+      tag: v2.15.0-20251226
+    resizer:
+      # -- Registry for the CSI Resizer image. When unspecified, Longhorn uses the default value.
+      registry: ""
+      # -- Repository for the CSI Resizer image. When unspecified, Longhorn uses the default value.
+      repository: longhornio/csi-resizer
+      # -- Tag for the CSI Resizer image. When unspecified, Longhorn uses the default value.
+      tag: v2.0.0-20251226
+    snapshotter:
+      # -- Registry for the CSI Snapshotter image. When unspecified, Longhorn uses the default value.
+      registry: ""
+      # -- Repository for the CSI Snapshotter image. When unspecified, Longhorn uses the default value.
+      repository: longhornio/csi-snapshotter
+      # -- Tag for the CSI Snapshotter image. When unspecified, Longhorn uses the default value.
+      tag: v8.4.0-20251226
+    livenessProbe:
+      # -- Registry for the CSI liveness probe image. When unspecified, Longhorn uses the default value.
+      registry: ""
+      # -- Repository for the CSI liveness probe image. When unspecified, Longhorn uses the default value.
+      repository: longhornio/livenessprobe
+      # -- Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value.
+      tag: v2.17.0-20251226
+  openshift:
+    oauthProxy:
+      # -- Registry for the OAuth Proxy image. Specify the upstream image (for example, "quay.io/openshift/origin-oauth-proxy"). This setting applies only to OpenShift users.
+      registry: ""
+      # -- Repository for the OAuth Proxy image. Specify the upstream image (for example, "quay.io/openshift/origin-oauth-proxy"). This setting applies only to OpenShift users.
+      repository: ""
+      # -- Tag for the OAuth Proxy image. Specify OCP/OKD version 4.1 or later (including version 4.18, which is available at quay.io/openshift/origin-oauth-proxy:4.18). This setting applies only to OpenShift users.
+      tag: ""
+  # -- Image pull policy that applies to all user-deployed Longhorn components, such as Longhorn Manager, Longhorn driver, and Longhorn UI.
+  pullPolicy: IfNotPresent
+service:
+  ui:
+    # -- Service type for Longhorn UI. (Options: "ClusterIP", "NodePort", "LoadBalancer", "Rancher-Proxy")
+    type: LoadBalancer
+    # -- NodePort port number for Longhorn UI. When unspecified, Longhorn selects a free port between 30000 and 32767.
+    nodePort: null
+    # -- Class of a load balancer implementation
+    loadBalancerClass: ""
+    loadBalancerIP: 192.168.0.241
+    # -- Annotation for the Longhorn UI service.
+    annotations: 
+      external-dns.alpha.kubernetes.io/hostname: longhorn.homelab.test
+    ## If you want to set annotations for the Longhorn UI service, delete the `{}` in the line above
+    ## and uncomment this example block
+    #  annotation-key1: "annotation-value1"
+    #  annotation-key2: "annotation-value2"
+    labels: {}
+    ## If you want to set additional labels for the Longhorn UI service, delete the `{}` in the line above
+    ## and uncomment this example block
+    #  label-key1: "label-value1"
+    #  label-key2: "label-value2"
+  manager:
+    # -- Service type for Longhorn Manager.
+    type: ClusterIP
+    # -- NodePort port number for Longhorn Manager. When unspecified, Longhorn selects a free port between 30000 and 32767.
+    nodePort: ""
+persistence:
+  # -- Setting that allows you to specify the default Longhorn StorageClass.
+  defaultClass: true
+  # -- Filesystem type of the default Longhorn StorageClass.
+  defaultFsType: ext4
+  # -- mkfs parameters of the default Longhorn StorageClass.
+  defaultMkfsParams: ""
+  # -- Replica count of the default Longhorn StorageClass.
+  defaultClassReplicaCount: 1
+  # -- Data locality of the default Longhorn StorageClass. (Options: "disabled", "best-effort")
+  defaultDataLocality: disabled
+  # -- Reclaim policy that provides instructions for handling of a volume after its claim is released. (Options: "Retain", "Delete")
+  reclaimPolicy: Delete
+  # -- VolumeBindingMode controls when volume binding and dynamic provisioning should occur. (Options: "Immediate", "WaitForFirstConsumer") (Defaults to "Immediate")
+  volumeBindingMode: "Immediate"
+  # -- Setting that allows you to enable live migration of a Longhorn volume from one node to another.
+  migratable: false
+  # -- Setting that disables the revision counter and thereby prevents Longhorn from tracking all write operations to a volume. When salvaging a volume, Longhorn uses properties of the volume-head-xxx.img file (the last file size and the last time the file was modified) to select the replica to be used for volume recovery.
+  disableRevisionCounter: "true"
+  # -- Set NFS mount options for Longhorn StorageClass for RWX volumes
+  nfsOptions: ""
+  recurringJobSelector:
+    # -- Setting that allows you to enable the recurring job selector for a Longhorn StorageClass.
+    enable: false
+    # -- Recurring job selector for a Longhorn StorageClass. Ensure that quotes are used correctly when specifying job parameters. (Example: `[{"name":"backup", "isGroup":true}]`)
+    jobList: []
+  backingImage:
+    # -- Setting that allows you to use a backing image in a Longhorn StorageClass.
+    enable: false
+    # -- Backing image to be used for creating and restoring volumes in a Longhorn StorageClass. When no backing images are available, specify the data source type and parameters that Longhorn can use to create a backing image.
+    name: ~
+    # -- Data source type of a backing image used in a Longhorn StorageClass.
+    # If the backing image exists in the cluster, Longhorn uses this setting to verify the image.
+    # If the backing image does not exist, Longhorn creates one using the specified data source type.
+    dataSourceType: ~
+    # -- Data source parameters of a backing image used in a Longhorn StorageClass.
+    # You can specify a JSON string of a map. (Example: `'{\"url\":\"https://backing-image-example.s3-region.amazonaws.com/test-backing-image\"}'`)
+    dataSourceParameters: ~
+    # -- Expected SHA-512 checksum of a backing image used in a Longhorn StorageClass.
+    expectedChecksum: ~
+  defaultDiskSelector:
+    # -- Setting that allows you to enable the disk selector for the default Longhorn StorageClass.
+    enable: false
+    # -- Disk selector for the default Longhorn StorageClass. Longhorn uses only disks with the specified tags for storing volume data. (Examples: "nvme,sata")
+    selector: ""
+  defaultNodeSelector:
+    # -- Setting that allows you to enable the node selector for the default Longhorn StorageClass.
+    enable: false
+    # -- Node selector for the default Longhorn StorageClass. Longhorn uses only nodes with the specified tags for storing volume data. (Examples: "storage,fast")
+    selector: ""
+  # -- Setting that allows you to enable automatic snapshot removal during filesystem trim for a Longhorn StorageClass. (Options: "ignored", "enabled", "disabled")
+  unmapMarkSnapChainRemoved: ignored
+  # -- Setting that allows you to specify the data engine version for the default Longhorn StorageClass. (Options: "v1", "v2")
+  dataEngine: v1
+  # -- Setting that allows you to specify the backup target for the default Longhorn StorageClass.
+  backupTargetName: default
+preUpgradeChecker:
+  # -- Setting that allows Longhorn to perform pre-upgrade checks. Disable this setting when installing Longhorn using Argo CD or other GitOps solutions.
+  jobEnabled: true
+  # -- Setting that allows Longhorn to perform upgrade version checks after starting the Longhorn Manager DaemonSet Pods. Disabling this setting also disables `preUpgradeChecker.jobEnabled`. Longhorn recommends keeping this setting enabled.
+  upgradeVersionCheck: true
+csi:
+  # -- kubelet root directory. When unspecified, Longhorn uses the default value.
+  kubeletRootDir: ~
+  # -- Configures Pod anti-affinity to prevent multiple instances on the same node. Use soft (tries to separate) or hard (must separate). When unspecified, Longhorn uses the default value ("soft").
+  podAntiAffinityPreset: ~
+  # -- Replica count of the CSI Attacher. When unspecified, Longhorn uses the default value ("3").
+  attacherReplicaCount: ~
+  # -- Replica count of the CSI Provisioner. When unspecified, Longhorn uses the default value ("3").
+  provisionerReplicaCount: ~
+  # -- Replica count of the CSI Resizer. When unspecified, Longhorn uses the default value ("3").
+  resizerReplicaCount: ~
+  # -- Replica count of the CSI Snapshotter. When unspecified, Longhorn uses the default value ("3").
+  snapshotterReplicaCount: ~
+defaultSettings:
+  # -- Setting that allows Longhorn to automatically attach a volume and create snapshots or backups when recurring jobs are run.
+  allowRecurringJobWhileVolumeDetached: ~
+  # -- Setting that allows Longhorn to automatically create a default disk only on nodes with the label "node.longhorn.io/create-default-disk=true" (if no other disks exist). When this setting is disabled, Longhorn creates a default disk on each node that is added to the cluster.
+  createDefaultDiskLabeledNodes: ~
+  # -- Default path to use for storing data on a host. An absolute directory path indicates a filesystem-type disk used by the V1 Data Engine, while a path to a block device indicates a block-type disk used by the V2 Data Engine. The default value is "/var/lib/longhorn/".
+  defaultDataPath: ~
+  # -- Default data locality. A Longhorn volume has data locality if a local replica of the volume exists on the same node as the pod that is using the volume.
+  defaultDataLocality: ~
+  # -- Setting that allows scheduling on nodes with healthy replicas of the same volume. This setting is disabled by default.
+  replicaSoftAntiAffinity: ~
+  # -- Setting that automatically rebalances replicas when an available node is discovered.
+  replicaAutoBalance: ~
+  # -- Percentage of storage that can be allocated relative to hard drive capacity. The default value is "100".
+  storageOverProvisioningPercentage: ~
+  # -- Percentage of minimum available disk capacity. When the minimum available capacity exceeds the total available capacity, the disk becomes unschedulable until more space is made available for use. The default value is "25".
+  storageMinimalAvailablePercentage: ~
+  # -- Percentage of disk space that is not allocated to the default disk on each new Longhorn node.
+  storageReservedPercentageForDefaultDisk: ~
+  # -- Upgrade Checker that periodically checks for new Longhorn versions. When a new version is available, a notification appears on the Longhorn UI. This setting is enabled by default
+  upgradeChecker: ~
+  # -- The Upgrade Responder sends a notification whenever a new Longhorn version that you can upgrade to becomes available. The default value is https://longhorn-upgrade-responder.rancher.io/v1/checkupgrade.
+  upgradeResponderURL: ~
+  # -- The external URL used to access the Longhorn Manager API. When set, this URL is returned in API responses (the actions and links fields) instead of the internal pod IP. This is useful when accessing the API through Ingress or Gateway API HTTPRoute. Format: scheme://host[:port] (for example, https://longhorn.example.com or https://longhorn.example.com:8443). Leave it empty to use the default behavior.
+  managerUrl: ~
+  # -- Default number of replicas for volumes created using the Longhorn UI. For Kubernetes configuration, modify the `numberOfReplicas` field in the StorageClass. The default value is "{"v1":"3","v2":"3"}".
+  defaultReplicaCount: ~
+  # -- Default name of Longhorn static StorageClass. "storageClassName" is assigned to PVs and PVCs that are created for an existing Longhorn volume. "storageClassName" can also be used as a label, so it is possible to use a Longhorn StorageClass to bind a workload to an existing PV without creating a Kubernetes StorageClass object. "storageClassName" needs to be an existing StorageClass. The default value is "longhorn-static".
+  defaultLonghornStaticStorageClass: ~
+  # -- Number of minutes that Longhorn keeps a failed backup resource. When the value is "0", automatic deletion is disabled.
+  failedBackupTTL: ~
+  # -- Number of minutes that Longhorn allows for the backup execution. The default value is "1".
+  backupExecutionTimeout: ~
+  # -- Setting that restores recurring jobs from a backup volume on a backup target and creates recurring jobs if none exist during backup restoration.
+  restoreVolumeRecurringJobs: ~
+  # -- Maximum number of successful recurring backup and snapshot jobs to be retained. When the value is "0", a history of successful recurring jobs is not retained.
+  recurringSuccessfulJobsHistoryLimit: ~
+  # -- Maximum number of failed recurring backup and snapshot jobs to be retained. When the value is "0", a history of failed recurring jobs is not retained.
+  recurringFailedJobsHistoryLimit: ~
+  # -- Maximum number of snapshots or backups to be retained.
+  recurringJobMaxRetention: ~
+  # -- Maximum number of failed support bundles that can exist in the cluster. When the value is "0", Longhorn automatically purges all failed support bundles.
+  supportBundleFailedHistoryLimit: ~
+  # -- Taint or toleration for system-managed Longhorn components.
+  # Specify values using a semicolon-separated list in `kubectl taint` syntax (Example: key1=value1:effect; key2=value2:effect).
+  taintToleration: ~
+  # -- Node selector for system-managed Longhorn components.
+  systemManagedComponentsNodeSelector: ~
+  # -- Resource limits for system-managed CSI components.
+  # This setting allows you to configure CPU and memory requests/limits for CSI attacher, provisioner, resizer, snapshotter, and plugin components.
+  # Supported components: csi-attacher, csi-provisioner, csi-resizer, csi-snapshotter, longhorn-csi-plugin, node-driver-registrar, longhorn-liveness-probe.
+  # Notice that changing resource limits will cause CSI components to restart, which may temporarily affect volume provisioning and attach/detach operations until the components are ready. The value should be a JSON object with component names as keys and ResourceRequirements as values.
+  systemManagedCSIComponentsResourceLimits: ~
+  # -- PriorityClass for system-managed Longhorn components.
+  # This setting can help prevent Longhorn components from being evicted under Node Pressure.
+  # Notice that this will be applied to Longhorn user-deployed components by default if there are no priority class values set yet, such as `longhornManager.priorityClass`.
+  priorityClass: &defaultPriorityClassNameRef "longhorn-critical"
+  # -- Setting that allows Longhorn to automatically salvage volumes when all replicas become faulty (for example, when the network connection is interrupted). Longhorn determines which replicas are usable and then uses these replicas for the volume. This setting is enabled by default.
+  autoSalvage: ~
+  # -- Setting that allows Longhorn to automatically delete a workload pod that is managed by a controller (for example, daemonset) whenever a Longhorn volume is detached unexpectedly (for example, during Kubernetes upgrades). After deletion, the controller restarts the pod and then Kubernetes handles volume reattachment and remounting.
+  autoDeletePodWhenVolumeDetachedUnexpectedly: ~
+  # -- Blacklist of controller api/kind values for the setting Automatically Delete Workload Pod when the Volume Is Detached Unexpectedly. If a workload pod is managed by a controller whose api/kind is listed in this blacklist, Longhorn will not automatically delete the pod when its volume is unexpectedly detached. Multiple controller api/kind entries can be specified, separated by semicolons. For example: `apps/StatefulSet;apps/DaemonSet`. Note that the controller api/kind is case sensitive and must exactly match the api/kind in the workload pod's owner reference.
+  blacklistForAutoDeletePodWhenVolumeDetachedUnexpectedly: ~
+  # -- Setting that prevents Longhorn Manager from scheduling replicas on a cordoned Kubernetes node. This setting is enabled by default.
+  disableSchedulingOnCordonedNode: ~
+  # -- Setting that allows Longhorn to schedule new replicas of a volume to nodes in the same zone as existing healthy replicas. Nodes that do not belong to any zone are treated as existing in the zone that contains healthy replicas. When identifying zones, Longhorn relies on the label "topology.kubernetes.io/zone=<Zone name of the node>" in the Kubernetes node object.
+  replicaZoneSoftAntiAffinity: ~
+  # -- Setting that allows scheduling on disks with existing healthy replicas of the same volume. This setting is enabled by default.
+  replicaDiskSoftAntiAffinity: ~
+  # -- Policy that defines the action Longhorn takes when a volume is stuck with a StatefulSet or Deployment pod on a node that failed.
+  nodeDownPodDeletionPolicy: ~
+  # -- Policy that defines the action Longhorn takes when a node with the last healthy replica of a volume is drained.
+  nodeDrainPolicy: ~
+  # -- Setting that allows automatic detaching of manually-attached volumes when a node is cordoned.
+  detachManuallyAttachedVolumesWhenCordoned: ~
+  # -- Number of seconds that Longhorn waits before reusing existing data on a failed replica instead of creating a new replica of a degraded volume.
+  replicaReplenishmentWaitInterval: ~
+  # -- Maximum number of replicas that can be concurrently rebuilt on each node.
+  concurrentReplicaRebuildPerNodeLimit: ~
+  # -- Maximum number of file synchronization operations that can run concurrently during a single replica rebuild. Right now, it's for v1 data engine only.
+  rebuildConcurrentSyncLimit: ~
+  # -- Maximum number of volumes that can be concurrently restored on each node using a backup. When the value is "0", restoration of volumes using a backup is disabled.
+  concurrentVolumeBackupRestorePerNodeLimit: ~
+  # -- Setting that disables the revision counter and thereby prevents Longhorn from tracking all write operations to a volume. When salvaging a volume, Longhorn uses properties of the "volume-head-xxx.img" file (the last file size and the last time the file was modified) to select the replica to be used for volume recovery. This setting applies only to volumes created using the Longhorn UI.
+  disableRevisionCounter: '{"v1":"true"}'
+  # -- Image pull policy for system-managed pods, such as Instance Manager, engine images, and CSI Driver. Changes to the image pull policy are applied only after the system-managed pods restart.
+  systemManagedPodsImagePullPolicy: ~
+  # -- Setting that allows you to create and attach a volume without having all replicas scheduled at the time of creation.
+  allowVolumeCreationWithDegradedAvailability: ~
+  # -- Setting that allows Longhorn to automatically clean up the system-generated snapshot after replica rebuilding is completed.
+  autoCleanupSystemGeneratedSnapshot: ~
+  # -- Setting that allows Longhorn to automatically clean up the snapshot generated by a recurring backup job.
+  autoCleanupRecurringJobBackupSnapshot: ~
+  # -- Maximum number of engines that are allowed to concurrently upgrade on each node after Longhorn Manager is upgraded. When the value is "0", Longhorn does not automatically upgrade volume engines to the new default engine image version.
+  concurrentAutomaticEngineUpgradePerNodeLimit: ~
+  # -- Number of minutes that Longhorn waits before cleaning up the backing image file when no replicas in the disk are using it.
+  backingImageCleanupWaitInterval: ~
+  # -- Number of seconds that Longhorn waits before downloading a backing image file again when the status of all image disk files changes to "failed" or "unknown".
+  backingImageRecoveryWaitInterval: ~
+  # -- Percentage of the total allocatable CPU resources on each node to be reserved for each instance manager pod. The default value is {"v1":"12","v2":"12"}.
+  guaranteedInstanceManagerCPU: ~
+  # -- Setting that notifies Longhorn that the cluster is using the Kubernetes Cluster Autoscaler.
+  kubernetesClusterAutoscalerEnabled: ~
+  # -- Enables Longhorn to automatically delete orphaned resources and their associated data or processes (e.g., stale replicas). Orphaned resources on failed or unknown nodes are not automatically cleaned up.
+  # You need to specify the resource types to be deleted using a semicolon-separated list (e.g., `replica-data;instance`). Available items are: `replica-data`, `instance`.
+  orphanResourceAutoDeletion: ~
+  # -- Specifies the wait time, in seconds, before Longhorn automatically deletes an orphaned Custom Resource (CR) and its associated resources.
+  # Note that if a user manually deletes an orphaned CR, the deletion occurs immediately and does not respect this grace period.
+  orphanResourceAutoDeletionGracePeriod: ~
+  # -- Storage network for in-cluster traffic. When unspecified, Longhorn uses the Kubernetes cluster network.
+  storageNetwork: ~
+  # -- Specifies a dedicated network for mounting RWX (ReadWriteMany) volumes. Leave this blank to use the default Kubernetes cluster network. **Caution**: This setting should change after all RWX volumes are detached because some Longhorn component pods must be recreated to apply the setting. You cannot modify this setting while RWX volumes are still attached.
+  endpointNetworkForRWXVolume: ~
+  # -- Flag that prevents accidental uninstallation of Longhorn.
+  deletingConfirmationFlag: true
+  # -- Timeout between the Longhorn Engine and replicas. Specify a value between "8" and "30" seconds. The default value is "8".
+  engineReplicaTimeout: ~
+  # -- Setting that allows you to enable and disable snapshot hashing and data integrity checks.
+  snapshotDataIntegrity: ~
+  # -- Setting that allows disabling of snapshot hashing after snapshot creation to minimize impact on system performance.
+  snapshotDataIntegrityImmediateCheckAfterSnapshotCreation: ~
+  # -- Setting that defines when Longhorn checks the integrity of data in snapshot disk files. You must use the Unix cron expression format.
+  snapshotDataIntegrityCronjob: ~
+  # -- Setting that controls how many snapshot heavy task operations (such as purge and clone) can run concurrently per node. This is a best-effort mechanism: due to the distributed nature of the system, temporary oversubscription may occur. The limiter reduces worst-case overload but does not guarantee perfect enforcement.
+  snapshotHeavyTaskConcurrentLimit: ~
+  # -- Setting that allows Longhorn to automatically mark the latest snapshot and its parent files as removed during a filesystem trim. Longhorn does not remove snapshots containing multiple child files.
+  removeSnapshotsDuringFilesystemTrim: ~
+  # -- Setting that allows fast rebuilding of replicas using the checksum of snapshot disk files. Before enabling this setting, you must set the snapshot-data-integrity value to "enable" or "fast-check".
+  fastReplicaRebuildEnabled: ~
+  # -- Number of seconds that an HTTP client waits for a response from a File Sync server before considering the connection to have failed.
+  replicaFileSyncHttpClientTimeout: ~
+  # -- Number of seconds that Longhorn allows for the completion of replica rebuilding and snapshot cloning operations.
+  longGRPCTimeOut: ~
+  # -- Log levels that indicate the type and severity of logs in Longhorn Manager. The default value is "Info". (Options: "Panic", "Fatal", "Error", "Warn", "Info", "Debug", "Trace")
+  logLevel: ~
+  # -- Specifies the directory on the host where Longhorn stores log files for the instance manager pod. Currently, it is only used for instance manager pods in the v2 data engine.
+  logPath: ~
+  # -- Setting that allows you to specify a backup compression method.
+  backupCompressionMethod: ~
+  # -- Maximum number of worker threads that can concurrently run for each backup.
+  backupConcurrentLimit: ~
+  # -- Specifies the default backup block size, in MiB, used when creating a new volume. Supported values are 2 or 16.
+  defaultBackupBlockSize: ~
+  # -- Maximum number of worker threads that can concurrently run for each restore operation.
+  restoreConcurrentLimit: ~
+  # -- Setting that allows you to enable the V1 Data Engine.
+  v1DataEngine: ~
+  # -- Setting that allows you to enable the V2 Data Engine, which is based on the Storage Performance Development Kit (SPDK). The V2 Data Engine is an experimental feature and should not be used in production environments.
+  v2DataEngine: ~
+  # -- Applies only to the V2 Data Engine. Enables hugepages for the Storage Performance Development Kit (SPDK) target daemon. If disabled, legacy memory is used. Allocation size is set via the Data Engine Memory Size setting.
+  dataEngineHugepageEnabled: ~
+  # -- Applies only to the V2 Data Engine. Specifies the hugepage size, in MiB, for the Storage Performance Development Kit (SPDK) target daemon. The default value is "{"v2":"2048"}"
+  dataEngineMemorySize: ~
+  # -- Applies only to the V2 Data Engine. Specifies the CPU cores on which the Storage Performance Development Kit (SPDK) target daemon runs. The daemon is deployed in each Instance Manager pod. Ensure that the number of assigned cores does not exceed the guaranteed Instance Manager CPUs for the V2 Data Engine. The default value is "{"v2":"0x1"}".
+  dataEngineCPUMask: ~
+  # -- This setting specifies the default write bandwidth limit (in megabytes per second) for volume replica rebuilding when using the v2 data engine (SPDK). If this value is set to 0, there will be no write bandwidth limitation. Individual volumes can override this setting by specifying their own rebuilding bandwidth limit.
+  replicaRebuildingBandwidthLimit: ~
+  # -- This setting specifies the default depth of each queue for Ublk frontend. This setting applies to volumes using the V2 Data Engine with Ublk front end. Individual volumes can override this setting by specifying their own Ublk queue depth.
+  defaultUblkQueueDepth: ~
+  # -- This setting specifies the default the number of queues for ublk frontend. This setting applies to volumes using the V2 Data Engine with Ublk front end. Individual volumes can override this setting by specifying their own number of queues for ublk.
+  defaultUblkNumberOfQueue: ~
+  # -- In seconds. The setting specifies the timeout for the instance manager pod liveness probe. The default value is 10 seconds.
+  instanceManagerPodLivenessProbeTimeout: ~
+  # -- Setting that allows scheduling of empty node selector volumes to any node.
+  allowEmptyNodeSelectorVolume: ~
+  # -- Setting that allows scheduling of empty disk selector volumes to any disk.
+  allowEmptyDiskSelectorVolume: ~
+  # -- Setting that allows Longhorn to periodically collect anonymous usage data for product improvement purposes. Longhorn sends collected data to the [Upgrade Responder](https://github.com/longhorn/upgrade-responder) server, which is the data source of the Longhorn Public Metrics Dashboard (https://metrics.longhorn.io). The Upgrade Responder server does not store data that can be used to identify clients, including IP addresses.
+  allowCollectingLonghornUsageMetrics: ~
+  # -- Setting that temporarily prevents all attempts to purge volume snapshots.
+  disableSnapshotPurge: ~
+  # -- Maximum snapshot count for a volume. The value should be between 2 to 250
+  snapshotMaxCount: ~
+  # -- Applies only to the V2 Data Engine. Specifies the log level for the Storage Performance Development Kit (SPDK) target daemon. Supported values are: Error, Warning, Notice, Info, and Debug. The default is Notice.
+  dataEngineLogLevel: ~
+  # -- Applies only to the V2 Data Engine. Specifies the log flags for the Storage Performance Development Kit (SPDK) target daemon.
+  dataEngineLogFlags: ~
+  # -- Setting that freezes the filesystem on the root partition before a snapshot is created.
+  freezeFilesystemForSnapshot: ~
+  # -- Setting that automatically cleans up the snapshot when the backup is deleted.
+  autoCleanupSnapshotWhenDeleteBackup: ~
+  # -- Setting that automatically cleans up the snapshot after the on-demand backup is completed.
+  autoCleanupSnapshotAfterOnDemandBackupCompleted: ~
+  # -- Setting that allows Longhorn to detect node failure and immediately migrate affected RWX volumes.
+  rwxVolumeFastFailover: ~
+  # -- Enables automatic rebuilding of degraded replicas while the volume is detached. This setting only takes effect if the individual volume setting is set to `ignored` or `enabled`.
+  offlineReplicaRebuilding: ~
+  # -- Controls whether Longhorn monitors and records health information for node disks. When disabled, disk health checks and status updates are skipped.
+  nodeDiskHealthMonitoring: ~
+# -- Setting that allows you to update the default backupstore.
+defaultBackupStore:
+  # -- Endpoint used to access the default backupstore. (Options: "NFS", "CIFS", "AWS", "GCP", "AZURE")
+  backupTarget: ~
+  # -- Name of the Kubernetes secret associated with the default backup target.
+  backupTargetCredentialSecret: ~
+  # -- Number of seconds that Longhorn waits before checking the default backupstore for new backups. The default value is "300". When the value is "0", polling is disabled.
+  pollInterval: ~
+privateRegistry:
+  # -- Set to `true` to automatically create a new private registry secret.
+  createSecret: ~
+  # -- URL of a private registry. When unspecified, Longhorn uses the default system registry.
+  registryUrl: ~
+  # -- User account used for authenticating with a private registry.
+  registryUser: ~
+  # -- Password for authenticating with a private registry.
+  registryPasswd: ~
+  # -- If create a new private registry secret is true, create a Kubernetes secret with this name; else use the existing secret of this name. Use it to pull images from your private registry.
+  registrySecret: ~
+longhornManager:
+  log:
+    # -- Format of Longhorn Manager logs. (Options: "plain", "json")
+    format: plain
+  # -- PriorityClass for Longhorn Manager.
+  priorityClass: *defaultPriorityClassNameRef
+  # -- Toleration for Longhorn Manager on nodes allowed to run Longhorn components.
+  tolerations: []
+  ## If you want to set tolerations for Longhorn Manager DaemonSet, delete the `[]` in the line above
+  ## and uncomment this example block
+  # - key: "key"
+  #   operator: "Equal"
+  #   value: "value"
+  #   effect: "NoSchedule"
+  # -- Resource requests and limits for Longhorn Manager pods.
+  resources: ~
+  # -- Node selector for Longhorn Manager. Specify the nodes allowed to run Longhorn Manager.
+  nodeSelector: {}
+  ## If you want to set node selector for Longhorn Manager DaemonSet, delete the `{}` in the line above
+  ## and uncomment this example block
+  #  label-key1: "label-value1"
+  #  label-key2: "label-value2"
+  # -- Annotation for the Longhorn Manager service.
+  serviceAnnotations: {}
+  ## If you want to set annotations for the Longhorn Manager service, delete the `{}` in the line above
+  ## and uncomment this example block
+  #  annotation-key1: "annotation-value1"
+  #  annotation-key2: "annotation-value2"
+  serviceLabels: {}
+  ## If you want to set labels for the Longhorn Manager service, delete the `{}` in the line above
+  ## and uncomment this example block
+  #  label-key1: "label-value1"
+  #  label-key2: "label-value2"
+  ## DaemonSet update strategy. Default "100% unavailable" matches the upgrade
+  ## flow (old managers removed before new start); override for rolling updates
+  ## if you prefer that behavior.
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: "100%"
+longhornDriver:
+  log:
+    # -- Format of longhorn-driver logs. (Options: "plain", "json")
+    format: plain
+  # -- PriorityClass for Longhorn Driver.
+  priorityClass: *defaultPriorityClassNameRef
+  # -- Toleration for Longhorn Driver on nodes allowed to run Longhorn components.
+  tolerations: []
+  ## If you want to set tolerations for Longhorn Driver Deployer Deployment, delete the `[]` in the line above
+  ## and uncomment this example block
+  # - key: "key"
+  #   operator: "Equal"
+  #   value: "value"
+  #   effect: "NoSchedule"
+  # -- Node selector for Longhorn Driver. Specify the nodes allowed to run Longhorn Driver.
+  nodeSelector: {}
+  ## If you want to set node selector for Longhorn Driver Deployer Deployment, delete the `{}` in the line above
+  ## and uncomment this example block
+  #  label-key1: "label-value1"
+  #  label-key2: "label-value2"
+longhornUI:
+  # -- Replica count for Longhorn UI.
+  replicas: 2
+  # -- PriorityClass for Longhorn UI.
+  priorityClass: *defaultPriorityClassNameRef
+  # -- Affinity for Longhorn UI pods. Specify the affinity you want to use for Longhorn UI.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                    - longhorn-ui
+            topologyKey: kubernetes.io/hostname
+  # -- Toleration for Longhorn UI on nodes allowed to run Longhorn components.
+  tolerations: []
+  ## If you want to set tolerations for Longhorn UI Deployment, delete the `[]` in the line above
+  ## and uncomment this example block
+  # - key: "key"
+  #   operator: "Equal"
+  #   value: "value"
+  #   effect: "NoSchedule"
+  # -- Node selector for Longhorn UI. Specify the nodes allowed to run Longhorn UI.
+  nodeSelector: {}
+  ## If you want to set node selector for Longhorn UI Deployment, delete the `{}` in the line above
+  ## and uncomment this example block
+  #  label-key1: "label-value1"
+  #  label-key2: "label-value2"
+ingress:
+  # -- Setting that allows Longhorn to generate ingress records for the Longhorn UI service.
+  enabled: false
+  # -- IngressClass resource that contains ingress configuration, including the name of the Ingress controller.
+  # ingressClassName can replace the kubernetes.io/ingress.class annotation used in earlier Kubernetes releases.
+  ingressClassName: ~
+  # -- Hostname of the Layer 7 load balancer.
+  host: sslip.io
+  # -- Extra hostnames for TLS (Subject Alternative Names - SAN). Used when you need multiple FQDNs for the same ingress.
+  # Example:
+  # extraHosts:
+  #   - longhorn.example.com
+  #   - longhorn-ui.internal.local
+  extraHosts: []
+  # -- Setting that allows you to enable TLS on ingress records.
+  tls: false
+  # -- Setting that allows you to enable secure connections to the Longhorn UI service via port 443.
+  secureBackends: false
+  # -- TLS secret that contains the private key and certificate to be used for TLS. This setting applies only when TLS is enabled on ingress records.
+  tlsSecret: longhorn.local-tls
+  # -- Default ingress path. You can access the Longhorn UI by following the full ingress path {{host}}+{{path}}.
+  path: /
+  # -- Ingress path type. To maintain backward compatibility, the default value is "ImplementationSpecific".
+  pathType: ImplementationSpecific
+  ## If you're using kube-lego, you will want to add:
+  ## kubernetes.io/tls-acme: true
+  ##
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ##
+  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+  # -- Ingress annotations in the form of key-value pairs.
+  annotations:
+  #  kubernetes.io/ingress.class: nginx
+  #  kubernetes.io/tls-acme: true
+
+  # -- Secret that contains a TLS private key and certificate. Use secrets if you want to use your own certificates to secure ingresses.
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using kube-lego, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: longhorn.local-tls
+  #   key:
+  #   certificate:
+httproute:
+  # -- Setting that allows Longhorn to generate HTTPRoute records for the Longhorn UI service using Gateway API.
+  enabled: false
+  # -- Gateway references for HTTPRoute. Specify which Gateway(s) should handle this route.
+  parentRefs: []
+  ## Example:
+  # - name: gateway-name
+  #   namespace: gateway-namespace
+  #   # Optional fields with defaults:
+  #   # group: gateway.networking.k8s.io  # default
+  #   # kind: Gateway                      # default
+  #   # sectionName: https                 # optional, targets a specific listener
+  # -- List of hostnames for the HTTPRoute. Multiple hostnames are supported.
+  hostnames: []
+  ## Example:
+  # - longhorn.example.com
+  # - longhorn.example.org
+  # -- Default path for HTTPRoute. You can access the Longhorn UI by following the full path.
+  path: /
+  # -- Path match type for HTTPRoute. (Options: "Exact", "PathPrefix")
+  pathType: PathPrefix
+  # -- Annotations for the HTTPRoute resource in the form of key-value pairs.
+  annotations: {}
+  ## Example:
+  #  annotation-key1: "annotation-value1"
+# -- Setting that allows you to enable pod security policies (PSPs) that allow privileged Longhorn pods to start. This setting applies only to clusters running Kubernetes 1.25 and earlier, and with the built-in Pod Security admission controller enabled.
+enablePSP: false
+# -- Specify override namespace, specifically this is useful for using longhorn as sub-chart and its release namespace is not the `longhorn-system`.
+namespaceOverride: ""
+# -- Annotation for the Longhorn Manager DaemonSet pods. This setting is optional.
+annotations: {}
+serviceAccount:
+  # -- Annotations to add to the service account
+  annotations: {}
+metrics:
+  serviceMonitor:
+    # -- Setting that allows the creation of a Prometheus ServiceMonitor resource for Longhorn Manager components.
+    enabled: false
+    # -- Additional labels for the Prometheus ServiceMonitor resource.
+    additionalLabels: {}
+    # -- Annotations for the Prometheus ServiceMonitor resource.
+    annotations: {}
+    # -- Interval at which Prometheus scrapes the metrics from the target.
+    interval: ""
+    # -- Timeout after which Prometheus considers the scrape to be failed.
+    scrapeTimeout: ""
+    # -- Configures the relabeling rules to apply the target’s metadata labels. See the [Prometheus Operator
+    # documentation](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Endpoint) for
+    # formatting details.
+    relabelings: []
+    # -- Configures the relabeling rules to apply to the samples before ingestion. See the [Prometheus Operator
+    # documentation](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Endpoint) for
+    # formatting details.
+    metricRelabelings: []
+## openshift settings
+openshift:
+  # -- Setting that allows Longhorn to integrate with OpenShift.
+  enabled: false
+  ui:
+    # -- Route for connections between Longhorn and the OpenShift web console.
+    route: "longhorn-ui"
+    # -- Port for accessing the OpenShift web console.
+    port: 443
+    # -- Port for proxy that provides access to the OpenShift web console.
+    proxy: 8443
+# -- Setting that allows Longhorn to generate code coverage profiles.
+enableGoCoverDir: false
+# -- Add extra objects manifests
+extraObjects: []

--- a/playbooks/k8s/install_longhorn_requirements.yml
+++ b/playbooks/k8s/install_longhorn_requirements.yml
@@ -1,6 +1,6 @@
 ---
 - name: setup and manage nodes
-  hosts: k8s
+  hosts: all
   become: true
   vars_files:
     - ../../vars/packages.yml
@@ -16,4 +16,3 @@
         name: iscsid
         state: started
         enabled: true
-


### PR DESCRIPTION
- external dns updates for kubernetes 1.33+ as endpoints get deprecated
- longhorn manifests to helmcharts